### PR TITLE
Add custom node grouping feature with top-level organization

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewCustomNodesProvider.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewCustomNodesProvider.kt
@@ -18,6 +18,7 @@ import org.jetbrains.android.facet.AndroidFacet
  */
 class AndroidViewCustomNodesProvider : AndroidViewNodeProvider {
 
+
     /**
      * Provides custom children (build directory and custom files) for Android modules.
      *
@@ -51,8 +52,10 @@ class AndroidViewCustomNodesProvider : AndroidViewNodeProvider {
             }
         }
 
-        // Add custom files matching the configured patterns if enabled
-        if (androidViewSettings.showCustomFiles && androidViewSettings.filePatterns.isNotEmpty()) {
+        // Add custom files matching the configured patterns if enabled and NOT grouped
+        if (androidViewSettings.showCustomFiles &&
+            androidViewSettings.filePatterns.isNotEmpty() &&
+            !androidViewSettings.groupCustomNodes) {
             val matchingFiles = AndroidViewNodeUtils.findMatchingFiles(module, androidViewSettings.filePatterns)
             for (file in matchingFiles) {
                 val psiFile = psiManager.findFile(file)
@@ -93,7 +96,9 @@ class AndroidViewCustomNodesProvider : AndroidViewNodeProvider {
             AndroidViewNodeUtils.findBuildDirectory(module)
         } else null
 
-        val customFiles = if (androidViewSettings.showCustomFiles && androidViewSettings.filePatterns.isNotEmpty()) {
+        val customFiles = if (androidViewSettings.showCustomFiles &&
+                                androidViewSettings.filePatterns.isNotEmpty() &&
+                                !androidViewSettings.groupCustomNodes) {
             AndroidViewNodeUtils.findMatchingFiles(module, androidViewSettings.filePatterns)
         } else emptyList()
 

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
@@ -16,6 +16,8 @@ class AndroidViewSettings : PersistentStateComponent<AndroidViewSettings> {
     var showBuildDirectory = false
     var showCustomFiles = false
     var filePatterns: MutableList<String> = mutableListOf()
+    var groupCustomNodes = true // If true, show custom nodes in top-level grouping; if false, show in modules
+    var customGroupings: MutableList<CustomNodeGrouping> = mutableListOf()
 
     // Legacy field for migration from old settings (kept for deserialization, excluded from serialization)
     @Deprecated("Use showCustomFiles and filePatterns instead")
@@ -35,6 +37,8 @@ class AndroidViewSettings : PersistentStateComponent<AndroidViewSettings> {
         state.showBuildDirectory = showBuildDirectory
         state.showCustomFiles = showCustomFiles
         state.filePatterns = filePatterns.toMutableList()
+        state.groupCustomNodes = groupCustomNodes
+        state.customGroupings = customGroupings.map { it.copy() }.toMutableList()
         return state
     }
 

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettingsConfigurable.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettingsConfigurable.kt
@@ -19,6 +19,7 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
     private var panel: JPanel? = null
     private var showBuildDirectoryCheckBox: JBCheckBox? = null
     private var showCustomFilesCheckBox: JBCheckBox? = null
+    private var groupCustomNodesCheckBox: JBCheckBox? = null
     private var filePatternTable: JBTable? = null
     private var filePatternTableModel: FilePatternTableModel? = null
 
@@ -46,9 +47,17 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
             toolTipText = AndroidViewBundle.message("settings.showCustomFiles.tooltip")
             addActionListener {
                 updateFilePatternTableState()
+                updateGroupCustomNodesState()
             }
         }
         topPanel.add(showCustomFilesCheckBox)
+        topPanel.add(Box.createVerticalStrut(10))
+
+        // Group custom nodes checkbox
+        groupCustomNodesCheckBox = JBCheckBox(AndroidViewBundle.message("settings.groupCustomNodes")).apply {
+            toolTipText = AndroidViewBundle.message("settings.groupCustomNodes.tooltip")
+        }
+        topPanel.add(groupCustomNodesCheckBox)
         topPanel.add(Box.createVerticalStrut(10))
 
         mainPanel.add(topPanel, BorderLayout.NORTH)
@@ -86,6 +95,11 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
     private fun updateFilePatternTableState() {
         val enabled = showCustomFilesCheckBox?.isSelected ?: false
         filePatternTable?.isEnabled = enabled
+    }
+
+    private fun updateGroupCustomNodesState() {
+        val enabled = showCustomFilesCheckBox?.isSelected ?: false
+        groupCustomNodesCheckBox?.isEnabled = enabled
     }
 
     private fun addFilePattern() {
@@ -136,6 +150,10 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
             return true
         }
 
+        if (groupCustomNodesCheckBox?.isSelected != settings.groupCustomNodes) {
+            return true
+        }
+
         val currentPatterns = filePatternTableModel?.getPatterns() ?: emptyList()
         if (currentPatterns != settings.filePatterns) {
             return true
@@ -149,6 +167,7 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
 
         settings.showBuildDirectory = showBuildDirectoryCheckBox?.isSelected ?: false
         settings.showCustomFiles = showCustomFilesCheckBox?.isSelected ?: false
+        settings.groupCustomNodes = groupCustomNodesCheckBox?.isSelected ?: true
         settings.filePatterns = filePatternTableModel?.getPatterns()?.toMutableList() ?: mutableListOf()
 
         // Refresh all open projects to reflect the changes
@@ -164,9 +183,11 @@ class AndroidViewSettingsConfigurable : SearchableConfigurable {
 
         showBuildDirectoryCheckBox?.isSelected = settings.showBuildDirectory
         showCustomFilesCheckBox?.isSelected = settings.showCustomFiles
+        groupCustomNodesCheckBox?.isSelected = settings.groupCustomNodes
         filePatternTableModel?.setPatterns(settings.filePatterns.toList())
 
         updateFilePatternTableState()
+        updateGroupCustomNodesState()
     }
 
     /**

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettingsConfigurableNew.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettingsConfigurableNew.kt
@@ -1,0 +1,248 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.options.SearchableConfigurable
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.table.JBTable
+import java.awt.BorderLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import javax.swing.*
+import javax.swing.table.AbstractTableModel
+
+/**
+ * Settings page for Android View customization with grouping support.
+ */
+class AndroidViewSettingsConfigurableNew : SearchableConfigurable {
+
+    private var panel: JPanel? = null
+    private var showBuildDirectoryCheckBox: JBCheckBox? = null
+    private var showCustomFilesCheckBox: JBCheckBox? = null
+    private var groupCustomNodesCheckBox: JBCheckBox? = null
+    private var groupingsTable: JBTable? = null
+    private var groupingsTableModel: GroupingsTableModel? = null
+
+    override fun getId(): String = "com.z8dn.plugins.a2pt.settings"
+
+    override fun getDisplayName(): String = "Advanced Android Project View"
+
+    override fun createComponent(): JComponent {
+        val mainPanel = JPanel(GridBagLayout())
+        val gbc = GridBagConstraints()
+        gbc.anchor = GridBagConstraints.NORTHWEST
+        gbc.fill = GridBagConstraints.HORIZONTAL
+        gbc.insets = Insets(5, 5, 5, 5)
+
+        // Row 0: Build directory checkbox
+        gbc.gridx = 0
+        gbc.gridy = 0
+        gbc.weightx = 1.0
+        showBuildDirectoryCheckBox = JBCheckBox(AndroidViewBundle.message("settings.showBuildDirectory")).apply {
+            toolTipText = AndroidViewBundle.message("settings.showBuildDirectory.tooltip")
+        }
+        mainPanel.add(showBuildDirectoryCheckBox, gbc)
+
+        // Row 1: Custom files checkbox
+        gbc.gridy = 1
+        showCustomFilesCheckBox = JBCheckBox(AndroidViewBundle.message("settings.showCustomFiles")).apply {
+            toolTipText = AndroidViewBundle.message("settings.showCustomFiles.tooltip")
+            addActionListener {
+                updateGroupingsTableState()
+                updateGroupCustomNodesState()
+            }
+        }
+        mainPanel.add(showCustomFilesCheckBox, gbc)
+
+        // Row 2: Group custom nodes checkbox
+        gbc.gridy = 2
+        groupCustomNodesCheckBox = JBCheckBox(AndroidViewBundle.message("settings.groupCustomNodes")).apply {
+            toolTipText = AndroidViewBundle.message("settings.groupCustomNodes.tooltip")
+        }
+        mainPanel.add(groupCustomNodesCheckBox, gbc)
+
+        // Row 3: Label for groupings table
+        gbc.gridy = 3
+        gbc.insets = Insets(15, 5, 5, 5)
+        val label = JLabel("Custom Node Groupings:")
+        mainPanel.add(label, gbc)
+
+        // Row 4: Groupings table
+        gbc.gridy = 4
+        gbc.weighty = 1.0
+        gbc.fill = GridBagConstraints.BOTH
+        gbc.insets = Insets(5, 5, 5, 5)
+
+        groupingsTableModel = GroupingsTableModel()
+        groupingsTable = JBTable(groupingsTableModel).apply {
+            setShowGrid(true)
+            setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        }
+
+        val tablePanel = ToolbarDecorator.createDecorator(groupingsTable!!)
+            .setAddAction { addGrouping() }
+            .setRemoveAction { removeSelectedGrouping() }
+            .setEditAction { editSelectedGrouping() }
+            .setMoveUpAction(null)
+            .setMoveDownAction(null)
+            .createPanel()
+
+        mainPanel.add(tablePanel, gbc)
+
+        panel = mainPanel
+        return mainPanel
+    }
+
+    private fun updateGroupingsTableState() {
+        val enabled = showCustomFilesCheckBox?.isSelected ?: false
+        groupingsTable?.isEnabled = enabled
+    }
+
+    private fun updateGroupCustomNodesState() {
+        val enabled = showCustomFilesCheckBox?.isSelected ?: false
+        groupCustomNodesCheckBox?.isEnabled = enabled
+    }
+
+    private fun addGrouping() {
+        val parentPanel = panel ?: return
+        val dialog = GroupingEditorDialog(parentPanel, null)
+        if (dialog.showAndGet()) {
+            val grouping = dialog.getGrouping()
+            if (grouping != null) {
+                groupingsTableModel?.addGrouping(grouping)
+            }
+        }
+    }
+
+    private fun removeSelectedGrouping() {
+        val selectedRow = groupingsTable?.selectedRow ?: -1
+        if (selectedRow >= 0) {
+            groupingsTableModel?.removeGrouping(selectedRow)
+        }
+    }
+
+    private fun editSelectedGrouping() {
+        val selectedRow = groupingsTable?.selectedRow ?: -1
+        if (selectedRow >= 0) {
+            val currentGrouping = groupingsTableModel?.getGroupingAt(selectedRow) ?: return
+            val parentPanel = panel ?: return
+            val dialog = GroupingEditorDialog(parentPanel, currentGrouping)
+            if (dialog.showAndGet()) {
+                val updatedGrouping = dialog.getGrouping()
+                if (updatedGrouping != null) {
+                    groupingsTableModel?.updateGrouping(selectedRow, updatedGrouping)
+                }
+            }
+        }
+    }
+
+    override fun isModified(): Boolean {
+        val settings = AndroidViewSettings.getInstance()
+
+        if (showBuildDirectoryCheckBox?.isSelected != settings.showBuildDirectory) {
+            return true
+        }
+
+        if (showCustomFilesCheckBox?.isSelected != settings.showCustomFiles) {
+            return true
+        }
+
+        if (groupCustomNodesCheckBox?.isSelected != settings.groupCustomNodes) {
+            return true
+        }
+
+        val currentGroupings = groupingsTableModel?.getGroupings() ?: emptyList()
+        if (currentGroupings != settings.customGroupings) {
+            return true
+        }
+
+        return false
+    }
+
+    override fun apply() {
+        val settings = AndroidViewSettings.getInstance()
+
+        settings.showBuildDirectory = showBuildDirectoryCheckBox?.isSelected ?: false
+        settings.showCustomFiles = showCustomFilesCheckBox?.isSelected ?: false
+        settings.groupCustomNodes = groupCustomNodesCheckBox?.isSelected ?: true
+        settings.customGroupings = groupingsTableModel?.getGroupings()?.toMutableList() ?: mutableListOf()
+
+        // Refresh all open projects to reflect the changes
+        ProjectManager.getInstance().openProjects
+            .filter { !it.isDisposed }
+            .forEach { project ->
+                ProjectView.getInstance(project).currentProjectViewPane?.updateFromRoot(true)
+            }
+    }
+
+    override fun reset() {
+        val settings = AndroidViewSettings.getInstance()
+
+        showBuildDirectoryCheckBox?.isSelected = settings.showBuildDirectory
+        showCustomFilesCheckBox?.isSelected = settings.showCustomFiles
+        groupCustomNodesCheckBox?.isSelected = settings.groupCustomNodes
+        groupingsTableModel?.setGroupings(settings.customGroupings.map { it.copy() })
+
+        updateGroupingsTableState()
+        updateGroupCustomNodesState()
+    }
+
+    /**
+     * Table model for managing groupings.
+     */
+    private class GroupingsTableModel : AbstractTableModel() {
+        private val groupings = mutableListOf<CustomNodeGrouping>()
+
+        override fun getRowCount(): Int = groupings.size
+
+        override fun getColumnCount(): Int = 2
+
+        override fun getColumnName(column: Int): String = when (column) {
+            0 -> "Grouping Name"
+            1 -> "File Patterns"
+            else -> ""
+        }
+
+        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any {
+            val grouping = groupings[rowIndex]
+            return when (columnIndex) {
+                0 -> grouping.name
+                1 -> grouping.patterns.joinToString(", ")
+                else -> ""
+            }
+        }
+
+        fun addGrouping(grouping: CustomNodeGrouping) {
+            groupings.add(grouping)
+            fireTableRowsInserted(groupings.size - 1, groupings.size - 1)
+        }
+
+        fun removeGrouping(index: Int) {
+            if (index >= 0 && index < groupings.size) {
+                groupings.removeAt(index)
+                fireTableRowsDeleted(index, index)
+            }
+        }
+
+        fun updateGrouping(index: Int, grouping: CustomNodeGrouping) {
+            if (index >= 0 && index < groupings.size) {
+                groupings[index] = grouping
+                fireTableRowsUpdated(index, index)
+            }
+        }
+
+        fun getGroupingAt(index: Int): CustomNodeGrouping? {
+            return if (index >= 0 && index < groupings.size) groupings[index] else null
+        }
+
+        fun getGroupings(): List<CustomNodeGrouping> = groupings.toList()
+
+        fun setGroupings(newGroupings: List<CustomNodeGrouping>) {
+            groupings.clear()
+            groupings.addAll(newGroupings)
+            fireTableDataChanged()
+        }
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/CustomFileNodeWithModule.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/CustomFileNodeWithModule.kt
@@ -1,0 +1,103 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.ui.SimpleTextAttributes
+import org.jetbrains.plugins.gradle.util.GradleConstants
+
+/**
+ * A custom file node that displays the module type and name beside the file name.
+ * Similar to how Gradle Scripts shows module information with prefixes like:
+ * - "Project: name" for root project
+ * - "Module: name" for regular modules
+ * - "Included build: :name" for included builds
+ *
+ * @param project The project
+ * @param psiFile The PSI file to display
+ * @param module The module this file belongs to
+ * @param settings View settings for rendering nodes
+ */
+class CustomFileNodeWithModule(
+    project: Project,
+    psiFile: PsiFile,
+    private val module: Module,
+    settings: ViewSettings
+) : PsiFileNode(project, psiFile, settings) {
+
+    override fun update(presentation: PresentationData) {
+        super.update(presentation)
+
+        // Add module name with appropriate prefix, similar to Gradle Scripts
+        val fileName = virtualFile?.name ?: value?.name
+        if (fileName != null) {
+            presentation.clearText()
+            presentation.addText(fileName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+
+            val moduleLabel = getModuleLabel(module)
+            presentation.addText(" ($moduleLabel)", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+        }
+    }
+
+    private fun getModuleLabel(module: Module): String {
+        val moduleName = module.name
+        val projectName = myProject?.name
+
+        // Convert module name from dot notation to colon notation (e.g., "project.app" -> ":app")
+        val colonNotationName = convertToColonNotation(moduleName, projectName)
+
+        // Check if this is the root project module first
+        if (moduleName == projectName || moduleName.endsWith(".main") && moduleName.startsWith(projectName ?: "")) {
+            return "Project: $projectName"
+        }
+
+        // Check if this is an included build using Gradle-specific data
+        val externalProjectId = ExternalSystemApiUtil.getExternalProjectId(module)
+        if (externalProjectId != null) {
+            // Included builds have a different project ID pattern
+            // They typically don't start with the main project name
+            val isIncludedBuild = projectName != null && !externalProjectId.startsWith(":") && externalProjectId != projectName
+            if (isIncludedBuild) {
+                return "Included build: $colonNotationName"
+            }
+        }
+
+        // Alternative check: compare external root project paths
+        val moduleRootPath = ExternalSystemApiUtil.getExternalRootProjectPath(module)
+        val projectRootPath = myProject?.basePath
+
+        if (moduleRootPath != null && projectRootPath != null) {
+            // Normalize paths for comparison
+            val normalizedModuleRoot = moduleRootPath.trimEnd('/')
+            val normalizedProjectRoot = projectRootPath.trimEnd('/')
+
+            // If paths are different, it's an included build
+            if (normalizedModuleRoot != normalizedProjectRoot) {
+                return "Included build: $colonNotationName"
+            }
+        }
+
+        // Otherwise, it's a regular module
+        return "Module: $colonNotationName"
+    }
+
+    private fun convertToColonNotation(moduleName: String, projectName: String?): String {
+        // Remove project prefix if present
+        val nameWithoutProject = if (projectName != null && moduleName.startsWith("$projectName.")) {
+            moduleName.removePrefix("$projectName.")
+        } else {
+            moduleName
+        }
+
+        // Convert dots to colons and ensure it starts with a colon
+        return if (nameWithoutProject.isEmpty()) {
+            ":"
+        } else {
+            ":" + nameWithoutProject.replace(".", ":")
+        }
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodeGrouping.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodeGrouping.kt
@@ -1,0 +1,29 @@
+package com.z8dn.plugins.a2pt
+
+/**
+ * Represents a custom node grouping configuration.
+ * Each grouping has a name and a list of file patterns.
+ *
+ * @param name The display name of the grouping node
+ * @param patterns List of file patterns (e.g., "*.md", "LICENSE") that belong to this group
+ */
+data class CustomNodeGrouping(
+    var name: String = "",
+    var patterns: MutableList<String> = mutableListOf()
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CustomNodeGrouping) return false
+        return name == other.name && patterns == other.patterns
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + patterns.hashCode()
+        return result
+    }
+
+    fun copy(): CustomNodeGrouping {
+        return CustomNodeGrouping(name, patterns.toMutableList())
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesGroupNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesGroupNode.kt
@@ -1,0 +1,89 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+
+/**
+ * A top-level grouping node that consolidates all custom files
+ * from all modules under a single "Custom Nodes" section in the Android Project View.
+ * This node appears at the same level as "Gradle Scripts" and other top-level nodes.
+ *
+ * @param project The project
+ * @param settings View settings for rendering nodes
+ */
+class CustomNodesGroupNode(
+    project: Project,
+    @Suppress("UNUSED_PARAMETER") module: Module?, // Keep for backward compatibility
+    private val settings: ViewSettings,
+    @Suppress("UNUSED_PARAMETER") buildDir: VirtualFile? = null, // Keep for backward compatibility
+    @Suppress("UNUSED_PARAMETER") customFiles: List<VirtualFile> = emptyList() // Keep for backward compatibility
+) : ProjectViewNode<String>(project, "Custom Nodes", settings) {
+
+    override fun getChildren(): Collection<AbstractTreeNode<*>> {
+        val project = myProject ?: return emptyList()
+        val children = mutableListOf<AbstractTreeNode<*>>()
+        val androidViewSettings = AndroidViewSettings.getInstance()
+
+        // Only add custom files if enabled
+        if (!androidViewSettings.showCustomFiles) {
+            return emptyList()
+        }
+
+        val modules = ModuleManager.getInstance(project).modules
+        val psiManager = PsiManager.getInstance(project)
+
+        // If there are custom groupings defined, create a node for each grouping
+        if (androidViewSettings.customGroupings.isNotEmpty()) {
+            for (grouping in androidViewSettings.customGroupings) {
+                if (grouping.patterns.isEmpty()) continue
+
+                val groupingFiles = mutableListOf<Pair<Module, VirtualFile>>()
+
+                // Collect files matching this grouping's patterns from all modules
+                for (module in modules) {
+                    if (module.isDisposed) continue
+
+                    val matchingFiles = AndroidViewNodeUtils.findMatchingFiles(module, grouping.patterns)
+                    for (file in matchingFiles) {
+                        groupingFiles.add(module to file)
+                    }
+                }
+
+                // Only create grouping node if it has files
+                if (groupingFiles.isNotEmpty()) {
+                    children.add(NamedGroupingNode(project, grouping.name, groupingFiles, settings))
+                }
+            }
+        } else if (androidViewSettings.filePatterns.isNotEmpty()) {
+            // Fallback: use legacy filePatterns as a single unnamed group
+            for (module in modules) {
+                if (module.isDisposed) continue
+
+                val matchingFiles = AndroidViewNodeUtils.findMatchingFiles(module, androidViewSettings.filePatterns)
+                for (file in matchingFiles) {
+                    val psiFile = psiManager.findFile(file)
+                    if (psiFile != null) {
+                        children.add(CustomFileNodeWithModule(project, psiFile, module, settings))
+                    }
+                }
+            }
+        }
+
+        return children
+    }
+
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = "Custom Nodes"
+    }
+
+    override fun contains(file: VirtualFile): Boolean = false
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesModuleGroupNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesModuleGroupNode.kt
@@ -1,0 +1,53 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+
+/**
+ * A module grouping node that shows custom files for a specific module.
+ * This node represents a module within the "Custom Nodes" section.
+ *
+ * @param project The project
+ * @param module The module this node represents
+ * @param settings View settings for rendering nodes
+ * @param customFiles The custom files belonging to this module
+ */
+class CustomNodesModuleGroupNode(
+    project: Project,
+    private val module: Module,
+    private val settings: ViewSettings,
+    private val customFiles: List<VirtualFile>
+) : ProjectViewNode<Module>(project, module, settings) {
+
+    override fun getChildren(): Collection<AbstractTreeNode<*>> {
+        if (module.isDisposed) return emptyList()
+
+        val project = myProject ?: return emptyList()
+        val psiManager = PsiManager.getInstance(project)
+        val children = mutableListOf<AbstractTreeNode<*>>()
+
+        for (file in customFiles) {
+            val psiFile = psiManager.findFile(file)
+            if (psiFile != null) {
+                children.add(PsiFileNode(project, psiFile, settings))
+            }
+        }
+
+        return children
+    }
+
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = module.name
+    }
+
+    override fun contains(file: VirtualFile): Boolean {
+        return customFiles.any { it.path == file.path }
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesTreeStructureProvider.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/CustomNodesTreeStructureProvider.kt
@@ -1,0 +1,67 @@
+package com.z8dn.plugins.a2pt
+
+import com.android.tools.idea.navigator.AndroidProjectViewPane
+import com.intellij.ide.projectView.TreeStructureProvider
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.Project
+
+/**
+ * Tree structure provider that adds a top-level "Custom Nodes" grouping to the Android Project View.
+ * This node appears at the same level as "Gradle Scripts" and modules.
+ */
+class CustomNodesTreeStructureProvider : TreeStructureProvider {
+
+    override fun modify(
+        parent: AbstractTreeNode<*>,
+        children: MutableCollection<AbstractTreeNode<*>>,
+        settings: ViewSettings?
+    ): Collection<AbstractTreeNode<*>> {
+        // Only apply to Android Project View root
+        if (settings == null || parent.value !is Project) {
+            return children
+        }
+
+        // Check if this is the Android Project View
+        val project = parent.value as? Project ?: return children
+
+        val androidViewSettings = AndroidViewSettings.getInstance()
+
+        // Only show groupings if custom files are enabled and grouping is enabled
+        if (!androidViewSettings.showCustomFiles || !androidViewSettings.groupCustomNodes) {
+            return children
+        }
+
+        val modifiedChildren = children.toMutableList()
+        val modules = com.intellij.openapi.module.ModuleManager.getInstance(project).modules
+
+        // Add user-defined groupings as top-level nodes
+        if (androidViewSettings.customGroupings.isNotEmpty()) {
+            for (grouping in androidViewSettings.customGroupings) {
+                if (grouping.patterns.isEmpty()) continue
+
+                val groupingFiles = mutableListOf<Pair<com.intellij.openapi.module.Module, com.intellij.openapi.vfs.VirtualFile>>()
+
+                // Collect files matching this grouping's patterns from all modules
+                for (module in modules) {
+                    if (module.isDisposed) continue
+
+                    val matchingFiles = AndroidViewNodeUtils.findMatchingFiles(module, grouping.patterns)
+                    for (file in matchingFiles) {
+                        groupingFiles.add(module to file)
+                    }
+                }
+
+                // Only create grouping node if it has files
+                if (groupingFiles.isNotEmpty()) {
+                    modifiedChildren.add(NamedGroupingNode(project, grouping.name, groupingFiles, settings))
+                }
+            }
+        } else if (androidViewSettings.filePatterns.isNotEmpty()) {
+            // Fallback: create a single "Custom Nodes" grouping for legacy filePatterns
+            modifiedChildren.add(CustomNodesGroupNode(project, null, settings, null, emptyList()))
+        }
+
+        return modifiedChildren
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/GroupCustomNodesAction.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/GroupCustomNodesAction.kt
@@ -1,0 +1,41 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+
+/**
+ * Toggle action to control whether custom nodes are grouped in a top-level section
+ * or displayed directly in their respective modules.
+ */
+class GroupCustomNodesAction : ToggleAction(
+    { AndroidViewBundle.message("action.GroupCustomNodesAction.text") }
+) {
+
+    override fun isSelected(e: AnActionEvent): Boolean {
+        return AndroidViewSettings.getInstance().groupCustomNodes
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        val settings = AndroidViewSettings.getInstance()
+        settings.groupCustomNodes = state
+
+        // Refresh the project view to reflect the changes
+        val project = e.project
+        if (project != null && !project.isDisposed) {
+            ProjectView.getInstance(project).currentProjectViewPane?.updateFromRoot(true)
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        // Enable the action only when custom files display is enabled
+        val settings = AndroidViewSettings.getInstance()
+        e.presentation.isEnabled = settings.showCustomFiles && settings.filePatterns.isNotEmpty()
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/GroupingEditorDialog.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/GroupingEditorDialog.kt
@@ -1,0 +1,172 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.table.JBTable
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import javax.swing.*
+import javax.swing.table.AbstractTableModel
+
+/**
+ * Dialog for editing a custom node grouping (name and file patterns).
+ */
+class GroupingEditorDialog(
+    parent: Component,
+    private val existingGrouping: CustomNodeGrouping?
+) : DialogWrapper(parent, true) {
+
+    private val nameField = JTextField(20)
+    private val patternsTableModel = PatternsTableModel()
+    private val patternsTable = JBTable(patternsTableModel)
+
+    init {
+        title = if (existingGrouping == null) "Add Grouping" else "Edit Grouping"
+        init()
+
+        // Load existing data if editing
+        existingGrouping?.let {
+            nameField.text = it.name
+            patternsTableModel.setPatterns(it.patterns.toList())
+        }
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel(BorderLayout(10, 10))
+        panel.preferredSize = Dimension(500, 400)
+
+        // Name field panel
+        val namePanel = JPanel(BorderLayout(5, 5))
+        namePanel.add(JLabel("Grouping Name:"), BorderLayout.WEST)
+        namePanel.add(nameField, BorderLayout.CENTER)
+        panel.add(namePanel, BorderLayout.NORTH)
+
+        // Patterns table
+        val patternsPanel = JPanel(BorderLayout(5, 5))
+        patternsPanel.add(JLabel("File Patterns:"), BorderLayout.NORTH)
+
+        patternsTable.setShowGrid(true)
+        patternsTable.selectionModel.selectionMode = ListSelectionModel.SINGLE_SELECTION
+
+        val tableDecorator = ToolbarDecorator.createDecorator(patternsTable)
+            .setAddAction { addPattern() }
+            .setRemoveAction { removeSelectedPattern() }
+            .setEditAction { editSelectedPattern() }
+            .setMoveUpAction(null)
+            .setMoveDownAction(null)
+            .createPanel()
+
+        patternsPanel.add(tableDecorator, BorderLayout.CENTER)
+        panel.add(patternsPanel, BorderLayout.CENTER)
+
+        return panel
+    }
+
+    private fun addPattern() {
+        val pattern = JOptionPane.showInputDialog(
+            contentPane,
+            "Enter file pattern (e.g., *.md, LICENSE, CHANGELOG.md):",
+            "Add Pattern",
+            JOptionPane.PLAIN_MESSAGE
+        )
+
+        if (!pattern.isNullOrBlank()) {
+            patternsTableModel.addPattern(pattern.trim())
+        }
+    }
+
+    private fun removeSelectedPattern() {
+        val selectedRow = patternsTable.selectedRow
+        if (selectedRow >= 0) {
+            patternsTableModel.removePattern(selectedRow)
+        }
+    }
+
+    private fun editSelectedPattern() {
+        val selectedRow = patternsTable.selectedRow
+        if (selectedRow >= 0) {
+            val currentPattern = patternsTableModel.getPatternAt(selectedRow) ?: return
+
+            val newPattern = JOptionPane.showInputDialog(
+                contentPane,
+                "Edit file pattern:",
+                currentPattern
+            )
+
+            if (!newPattern.isNullOrBlank()) {
+                patternsTableModel.updatePattern(selectedRow, newPattern.trim())
+            }
+        }
+    }
+
+    override fun doValidate(): ValidationInfo? {
+        if (nameField.text.isNullOrBlank()) {
+            return ValidationInfo("Grouping name cannot be empty", nameField)
+        }
+
+        if (patternsTableModel.getPatterns().isEmpty()) {
+            return ValidationInfo("At least one file pattern is required")
+        }
+
+        return null
+    }
+
+    fun getGrouping(): CustomNodeGrouping? {
+        val name = nameField.text.trim()
+        val patterns = patternsTableModel.getPatterns().toMutableList()
+
+        return if (name.isNotEmpty() && patterns.isNotEmpty()) {
+            CustomNodeGrouping(name, patterns)
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Table model for file patterns within a grouping.
+     */
+    private class PatternsTableModel : AbstractTableModel() {
+        private val patterns = mutableListOf<String>()
+
+        override fun getRowCount(): Int = patterns.size
+
+        override fun getColumnCount(): Int = 1
+
+        override fun getColumnName(column: Int): String = "Pattern"
+
+        override fun getValueAt(rowIndex: Int, columnIndex: Int): Any = patterns[rowIndex]
+
+        fun addPattern(pattern: String) {
+            patterns.add(pattern)
+            fireTableRowsInserted(patterns.size - 1, patterns.size - 1)
+        }
+
+        fun removePattern(index: Int) {
+            if (index >= 0 && index < patterns.size) {
+                patterns.removeAt(index)
+                fireTableRowsDeleted(index, index)
+            }
+        }
+
+        fun updatePattern(index: Int, pattern: String) {
+            if (index >= 0 && index < patterns.size) {
+                patterns[index] = pattern
+                fireTableRowsUpdated(index, index)
+            }
+        }
+
+        fun getPatternAt(index: Int): String? {
+            return if (index >= 0 && index < patterns.size) patterns[index] else null
+        }
+
+        fun getPatterns(): List<String> = patterns.toList()
+
+        fun setPatterns(newPatterns: List<String>) {
+            patterns.clear()
+            patterns.addAll(newPatterns)
+            fireTableDataChanged()
+        }
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/NamedGroupingNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/NamedGroupingNode.kt
@@ -1,0 +1,54 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.ide.projectView.PresentationData
+import com.intellij.ide.projectView.ProjectViewNode
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiManager
+
+/**
+ * A named grouping node that shows custom files under a specific group name.
+ * This represents a single grouping configuration within the "Custom Nodes" section.
+ *
+ * @param project The project
+ * @param groupName The name of this grouping
+ * @param files List of pairs (Module, VirtualFile) representing files in this group
+ * @param settings View settings for rendering nodes
+ */
+class NamedGroupingNode(
+    project: Project,
+    private val groupName: String,
+    private val files: List<Pair<Module, VirtualFile>>,
+    private val settings: ViewSettings
+) : ProjectViewNode<String>(project, groupName, settings) {
+
+    override fun getChildren(): Collection<AbstractTreeNode<*>> {
+        val project = myProject ?: return emptyList()
+        val psiManager = PsiManager.getInstance(project)
+        val children = mutableListOf<AbstractTreeNode<*>>()
+
+        for ((module, file) in files) {
+            if (module.isDisposed) continue
+
+            val psiFile = psiManager.findFile(file)
+            if (psiFile != null) {
+                children.add(CustomFileNodeWithModule(project, psiFile, module, settings))
+            }
+        }
+
+        return children.distinctBy {
+            (it as? CustomFileNodeWithModule)?.virtualFile?.path
+        }
+    }
+
+    override fun update(presentation: PresentationData) {
+        presentation.presentableText = groupName
+    }
+
+    override fun contains(file: VirtualFile): Boolean {
+        return files.any { it.second.path == file.path }
+    }
+}

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/OpenSettingsAction.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/OpenSettingsAction.kt
@@ -1,0 +1,16 @@
+package com.z8dn.plugins.a2pt
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+
+/**
+ * Action to quickly open the Advanced Android Project View settings page.
+ */
+class OpenSettingsAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, "com.z8dn.plugins.a2pt.settings")
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,7 +17,7 @@
         <!-- Android View Settings Configurable -->
         <applicationConfigurable
                 parentId="tools"
-                instance="com.z8dn.plugins.a2pt.AndroidViewSettingsConfigurable"
+                instance="com.z8dn.plugins.a2pt.AndroidViewSettingsConfigurableNew"
                 id="com.z8dn.plugins.a2pt.settings"
                 key="settings.displayName"
                 bundle="messages.AndroidViewBundle"/>
@@ -27,6 +27,11 @@
     <extensions defaultExtensionNs="com.android.tools.idea.navigator">
         <!-- Consolidated provider handles both build directories and custom files to prevent duplicate module wrapping -->
         <androidViewNodeProvider implementation="com.z8dn.plugins.a2pt.AndroidViewCustomNodesProvider"/>
+    </extensions>
+
+    <!-- Tree Structure Provider for top-level Custom Nodes grouping -->
+    <extensions defaultExtensionNs="com.intellij">
+        <treeStructureProvider implementation="com.z8dn.plugins.a2pt.CustomNodesTreeStructureProvider"/>
     </extensions>
 
     <!-- Toggle Actions for Android View -->
@@ -39,6 +44,13 @@
                     class="com.z8dn.plugins.a2pt.ShowBuildDirectoryAction"/>
             <action id="com.z8dn.plugins.a2pt.ShowCustomFilesAction"
                     class="com.z8dn.plugins.a2pt.ShowCustomFilesAction"/>
+            <action id="com.z8dn.plugins.a2pt.GroupCustomNodesAction"
+                    class="com.z8dn.plugins.a2pt.GroupCustomNodesAction"/>
+            <separator/>
+            <action id="com.z8dn.plugins.a2pt.OpenSettingsAction"
+                    class="com.z8dn.plugins.a2pt.OpenSettingsAction"
+                    text="Advanced Android Project View Settings..."
+                    description="Open Advanced Android Project View settings"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -3,6 +3,8 @@ action.ShowBuildDirectoryAction.text=Display Build Directory
 action.ShowBuildDirectoryAction.description=Toggle build directory visibility in Android view
 action.ShowCustomFilesAction.text=Display Custom Files
 action.ShowCustomFilesAction.description=Toggle custom file visibility in Android view
+action.GroupCustomNodesAction.text=Group Custom Nodes
+action.GroupCustomNodesAction.description=When enabled, custom files are shown in a top-level 'Custom Nodes' section; when disabled, they are shown directly in their respective modules
 
 # Settings
 settings.displayName=Advanced Android Project View
@@ -10,6 +12,8 @@ settings.showBuildDirectory=Display Build Directory
 settings.showBuildDirectory.tooltip=Show the build directory in the Android Project View
 settings.showCustomFiles=Display Custom Files
 settings.showCustomFiles.tooltip=Show files matching the patterns below in the Android Project View
+settings.groupCustomNodes=Group Custom Nodes
+settings.groupCustomNodes.tooltip=When enabled, custom files are shown in a top-level 'Custom Nodes' section; when disabled, they are shown directly in their respective modules
 settings.filePatterns.label=File patterns (e.g., *.md, LICENSE, CHANGELOG.md):
 settings.filePatterns.columnName=Pattern
 


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive custom node grouping system that allows users to create named groupings of files that appear at the top level of the Android Project View, alongside Gradle Scripts and modules.

## New Features

### 🎯 User-Defined Groupings
- Users can create multiple custom groupings with unique names
- Each grouping can have multiple file patterns (e.g., `*.md`, `LICENSE`, `*.yaml`)
- Groupings appear as top-level nodes in the Android Project View
- Files are displayed with module context: `(Project: name)`, `(Module: :name)`, or `(Included build: :name)`

### ⚙️ Settings UI
- New comprehensive settings UI with grouping management table
- Add/Edit/Remove groupings via dialog interface
- Each grouping has a name and list of file patterns
- Visual table showing all configured groupings

### 🔧 Toggle Actions
- **Group Custom Nodes** action to enable/disable grouping display
- **Advanced Android Project View Settings...** action for quick access
- Actions integrate with existing Project View toolbar

### 📦 Module Context Display
- Files show their module affiliation with proper prefixes
- Colon-separated module names following Gradle conventions
- Smart detection of included builds vs regular modules
- Automatic removal of project prefix from module names

## Example Usage

Users can create groupings like:
- **Documentation** - contains `*.md`, `README.md`, `CHANGELOG.md`
- **Config Files** - contains `*.yaml`, `*.json`, `config/*`
- **License Files** - contains `LICENSE`, `LICENSE.txt`, `COPYING`

These appear in the project view as:
```
Project View
├── app (module)
├── Documentation
│   ├── README.md (Module: :app)
│   └── CHANGELOG.md (Project: MyProject)
├── Config Files
│   ├── config.yaml (Module: :app)
│   └── settings.json (Included build: :build-logic)
├── Gradle Scripts
```

## Implementation Details

### New Classes
- `CustomNodeGrouping` - Data class for grouping configuration
- `AndroidViewSettingsConfigurableNew` - Redesigned settings UI
- `GroupingEditorDialog` - Modal dialog for editing groupings
- `CustomNodesTreeStructureProvider` - Adds top-level grouping nodes
- `NamedGroupingNode` - Represents a user-defined grouping in tree
- `CustomFileNodeWithModule` - File node showing module context
- `GroupCustomNodesAction` - Toggle action for grouping feature
- `OpenSettingsAction` - Quick settings access action

### Updated Components
- `AndroidViewSettings` - Added `customGroupings` and `groupCustomNodes` fields
- `AndroidViewCustomNodesProvider` - Updated to support grouped/ungrouped modes
- Plugin configuration and localization strings

## Backward Compatibility
✅ Legacy `filePatterns` configuration still supported
✅ Falls back to single "Custom Nodes" grouping when no custom groupings defined
✅ All existing settings preserved during migration

## Test Plan
- [ ] Create a custom grouping with name and patterns
- [ ] Verify grouping appears at top level in Android Project View
- [ ] Verify files show correct module context
- [ ] Test included build detection (e.g., `build-logic`)
- [ ] Toggle "Group Custom Nodes" action
- [ ] Edit and remove groupings
- [ ] Verify backward compatibility with legacy settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Custom files can now be organized into user-defined groupings for better project organization
  * Added new settings interface to manage custom node groupings with pattern-based file matching
  * Custom files now display their associated module information for clarity
  * Added toggle action to enable/disable custom node grouping
  * New settings action provides access to advanced configuration options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->