### PR TITLE
Remove legacy showReadme field and migration logic

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
@@ -19,10 +19,6 @@ class AndroidViewSettings : PersistentStateComponent<AndroidViewSettings> {
     var groupCustomNodes = true // If true, show custom nodes in top-level grouping; if false, show in modules
     var customGroupings: MutableList<CustomNodeGrouping> = mutableListOf()
 
-    // Legacy field for migration from old settings (kept for deserialization, excluded from serialization)
-    @Deprecated("Use showCustomFiles and filePatterns instead")
-    var showReadme: Boolean? = null
-
     companion object {
         @JvmStatic
         fun getInstance(): AndroidViewSettings {
@@ -44,13 +40,5 @@ class AndroidViewSettings : PersistentStateComponent<AndroidViewSettings> {
 
     override fun loadState(state: AndroidViewSettings) {
         XmlSerializerUtil.copyBean(state, this)
-
-        // Migration: if old showReadme was enabled and no patterns exist, add default README pattern
-        @Suppress("DEPRECATION")
-        if (showReadme == true && filePatterns.isEmpty()) {
-            filePatterns.add("README.md")
-            showCustomFiles = true
-            showReadme = null // Clear after migration
-        }
     }
 }


### PR DESCRIPTION
## Summary
- Removed deprecated `showReadme` field from `AndroidViewSettings`
- Removed associated migration code in `loadState()` method
- Cleaned up legacy code that is no longer needed

## Details
The `showReadme` field was a legacy field used for migration from old settings to the new `showCustomFiles` and `filePatterns` system. Since sufficient time has passed for users to migrate, this legacy code can now be safely removed.

## Test plan
- [ ] Verify plugin loads without errors
- [ ] Verify settings page works correctly
- [ ] Verify existing settings are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Custom file grouping with pattern-based organization – create named groups for custom project files
  * Advanced settings interface to manage groupings and file patterns
  * Group/ungroup toggle for custom files in the project view
  * Improved file organization capabilities in Android project view

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->