### PR TITLE
Fix initialization bugs for settings and view refresh

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewSettings.kt
@@ -36,15 +36,7 @@ class AndroidViewSettings : PersistentStateComponent<AndroidViewSettings> {
         }
     }
 
-    override fun getState(): AndroidViewSettings {
-        val state = AndroidViewSettings()
-        state.showBuildDirectory = showBuildDirectory
-        state.projectFileGroups = projectFileGroups.map {
-            ProjectFileGroup(it.groupName, it.patterns.toMutableList())
-        }.toMutableList()
-        state.showProjectFilesInModule = showProjectFilesInModule
-        return state
-    }
+    override fun getState(): AndroidViewSettings = this
 
     override fun loadState(state: AndroidViewSettings) {
         XmlSerializerUtil.copyBean(state, this)

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewStartupActivity.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewStartupActivity.kt
@@ -1,0 +1,28 @@
+package com.z8dn.plugins.a2pt
+
+import com.android.tools.idea.navigator.AndroidProjectViewPane
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Startup activity that refreshes the Android Project View when a project is opened.
+ *
+ * This ensures that project files and other custom nodes are displayed correctly
+ * when the IDE starts, without requiring the user to toggle view settings.
+ */
+class AndroidViewStartupActivity : ProjectActivity {
+    override suspend fun execute(project: Project) {
+        ApplicationManager.getApplication().invokeLater {
+            if (!project.isDisposed) {
+                val projectView = ProjectView.getInstance(project)
+                val currentPane = projectView.currentProjectViewPane
+
+                if (currentPane is AndroidProjectViewPane) {
+                    currentPane.updateFromRoot(true)
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,6 +21,9 @@
                 id="com.z8dn.plugins.a2pt.settings"
                 key="settings.displayName"
                 bundle="messages.AndroidViewBundle"/>
+
+        <!-- Startup Activity to refresh view on project open -->
+        <postStartupActivity implementation="com.z8dn.plugins.a2pt.AndroidViewStartupActivity"/>
     </extensions>
 
     <!-- Android View Node Providers -->


### PR DESCRIPTION
## Summary
- Simplify `getState()` to return `this` for proper state persistence
- Add `AndroidViewStartupActivity` to refresh view on project open
- Register startup activity in plugin.xml

## Fixes
- Settings not being saved on first IDE open
- Only 1 group appearing until toggling the display action

## Dependencies
- Based on #6 (smart icon implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)