### PR TITLE
Fix Android module node display

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewBuildAndReadmeProvider.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/AndroidViewBuildAndReadmeProvider.kt
@@ -75,13 +75,10 @@ class AndroidViewBuildAndReadmeProvider : AndroidViewNodeProvider {
         val project = module.project
         return when {
             androidFacet != null && apkFacet != null ->
-                listOf(
-                    ApkModuleNode(project, module, androidFacet, apkFacet, settings),
-                    ExternalLibrariesNode(project, settings)
-                )
+                emptyList()
 
             androidFacet != null && AndroidModel.isRequired(androidFacet) ->
-                listOf(AndroidModuleNode(project, module, settings))
+                emptyList()
 
             else -> listOf(GradleModuleWithProjectFiles(project, module, settings))
         }


### PR DESCRIPTION
## Summary
- Fix Android module nodes appearing in project tree by returning empty lists for Android modules with facets
- Preserve GradleModuleWithProjectFiles for other modules

## Changes
Modified `AndroidViewBuildAndReadmeProvider.kt` to return `emptyList()` for Android and APK modules instead of creating node instances.

## Test plan
- [ ] Verify Android modules no longer show extra nodes in project tree
- [ ] Verify Gradle modules still display correctly
- [ ] Test with projects containing multiple module types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaned up project view display by removing certain module nodes that were previously shown in specific build configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->