### PR TITLE
Feature: add Customize Android Tree View action

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/CustomizeAndroidTreeViewAction.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/CustomizeAndroidTreeViewAction.kt
@@ -1,0 +1,21 @@
+package com.z8dn.plugins.a2pt.actions
+
+import com.intellij.ide.actions.ShowSettingsUtilImpl
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.z8dn.plugins.a2pt.AndroidViewBundle
+import org.jetbrains.annotations.ApiStatus.Internal
+
+@Internal
+class CustomizeAndroidTreeViewAction : DumbAwareAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun actionPerformed(e: AnActionEvent) {
+        ShowSettingsUtilImpl.showSettingsDialog(
+            e.project,
+            "com.z8dn.plugins.a2pt.settings",
+            AndroidViewBundle.message("settings.DisplayName.text")
+        )
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,10 +44,15 @@
             <add-to-group group-id="ProjectView.ToolWindow.Appearance.Actions"
                           relative-to-action="ShowBuildFilesInModuleAction"
                           anchor="after"/>
+            <separator/>
             <action id="com.z8dn.plugins.a2pt.ShowBuildDirectoryAction"
                     class="com.z8dn.plugins.a2pt.actions.ShowBuildDirectoryAction"/>
             <action id="com.z8dn.plugins.a2pt.ShowProjectFilesInModuleAction"
                     class="com.z8dn.plugins.a2pt.actions.ShowProjectFilesInModuleAction"/>
+            <action id="CustomizeAndroidTreeViewAction"
+                    class="com.z8dn.plugins.a2pt.actions.CustomizeAndroidTreeViewAction"
+                    text="Customize Android Tree View..."
+                    description="Open Advanced Android Project View settings"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -1,6 +1,8 @@
 # Project View Actions
 action.ProjectView.ShowBuildDirectoryAction.text=Display Build Directory
 action.ProjectView.ShowProjectFilesInModuleAction.text=Display Project Files in Modules
+action.ProjectView.CustomizeAndroidTreeViewAction.text=Customize Android Tree View...
+action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project View settings
 
 # Settings
 settings.DisplayName.text=Advanced Android Project View


### PR DESCRIPTION
This PR introduces a new action 'Customize Android Tree View...' to easily access the plugin settings directly from the Android Project View appearance menu. This PR is stacked on top of #34.