### PR TITLE
Update plugin name to 'Advanced Android Project Tree'

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,1 @@
-Advanced Android Project View
+Advanced Android Project Tree

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Advanced Android Project View
+# Contributing to Advanced Android Project Tree
 
-Thank you for your interest in contributing to Advanced Android Project View! We welcome contributions from the community and are grateful for your support.
+Thank you for your interest in contributing to Advanced Android Project Tree! We welcome contributions from the community and are grateful for your support.
 
 ## Table of Contents
 
@@ -347,4 +347,4 @@ If you have questions about contributing:
 
 ---
 
-Thank you for contributing to Advanced Android Project View! 🎉
+Thank you for contributing to Advanced Android Project Tree! 🎉

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Advanced Android Project View (A2PT)</h1></br>
+<h1 align="center">Advanced Android Project Tree (A2PT)</h1></br>
 
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"/></a>
@@ -7,7 +7,7 @@
 </p>
 
 <!-- Plugin description -->
-<p><strong>Advanced Android Project View</strong> enhances the Android Studio project view by providing quick access to commonly used directories and files that are normally hidden or difficult to navigate to.</p>
+<p><strong>Advanced Android Project Tree</strong> enhances the Android Studio project view by providing quick access to commonly used directories and files that are normally hidden or difficult to navigate to.</p>
 
 <h3>Features</h3>
 <ul>
@@ -33,7 +33,7 @@ Have a suggestion? Feel free to open an [issue](https://github.com/z8dn/advanced
 ### From JetBrains Marketplace (Recommended)
 1. Open Android Studio/IntelliJ IDEA
 2. Go to **Settings/Preferences** (⌘, on Mac or Ctrl+Alt+S on Windows/Linux) → **Plugins** → **Marketplace**
-3. Search for "Advanced Android Project View"
+3. Search for "Advanced Android Project Tree"
 4. Click **Install** and restart Android Studio/IntelliJ IDEA
 ![img/plugin-marketplace-installation.png](img/plugin-marketplace-installation.png)
 
@@ -55,7 +55,7 @@ Have a suggestion? Feel free to open an [issue](https://github.com/z8dn/advanced
 Alternatively, right-click in the Project View toolbar and select appearance options.
 
 ### Configure Project File Groups
-1. Go to **Settings/Preferences** → **Tools** → **Advanced Android Project View**
+1. Go to **Settings/Preferences** → **Tools** → **Advanced Android Project Tree**
 2. Click **Add** to create a new file group
 3. Enter a group name (e.g., "Documentation", "AI Rules")
    ![img/settings-custom-file-groups.png](img/settings-custom-file-groups.png)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = com.z8dn.a2pt
-pluginName = Advanced Android Project View
+pluginName = Advanced Android Project Tree
 pluginRepositoryUrl = https://github.com/z8dn/advanced-android-project-view
 # SemVer format -> https://semver.org
 pluginVersion = 0.0.6

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "Advanced Android Project View"
+rootProject.name = "Advanced Android Project Tree"
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/settings/AndroidViewSettingsConfigurable.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/settings/AndroidViewSettingsConfigurable.kt
@@ -17,7 +17,7 @@ import javax.swing.*
 import javax.swing.table.AbstractTableModel
 
 /**
- * Settings page for Advanced Android Project View.
+ * Settings page for Advanced Android Project Tree.
  */
 class AndroidViewSettingsConfigurable : SearchableConfigurable {
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>com.z8dn.plugins.a2pt</id>
-    <name>Advanced Android Project View</name>
+    <name>Advanced Android Project Tree</name>
     <vendor url="https://z8dn.github.io/">Zayden</vendor>
 
     <depends>com.intellij.modules.platform</depends>
@@ -52,7 +52,7 @@
             <action id="CustomizeAndroidTreeViewAction"
                     class="com.z8dn.plugins.a2pt.actions.CustomizeAndroidTreeViewAction"
                     text="Customize Android Tree View..."
-                    description="Open Advanced Android Project View settings"/>
+                    description="Open Advanced Android Project Tree settings"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -2,10 +2,10 @@
 action.ProjectView.ShowBuildDirectoryAction.text=Display Build Directory
 action.ProjectView.ShowProjectFilesInModuleAction.text=Display Project Files in Modules
 action.ProjectView.CustomizeAndroidTreeViewAction.text=Customize Android Tree View...
-action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project View settings
+action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project Tree settings
 
 # Settings
-settings.DisplayName.text=Advanced Android Project View
+settings.DisplayName.text=Advanced Android Project Tree
 settings.ShowBuildDirectory.text=Show build directory
 settings.ShowBuildDirectory.description=Show the build directory in Android modules
 settings.CustomFileGroups.text=Custom File Groups


### PR DESCRIPTION
## Summary
- Renamed plugin display name from "Advanced Android Project View" to "Advanced Android Project Tree" to match the A2PT acronym consistently

## Changes
- Updated `pluginName` in `gradle.properties`
- Updated `<name>` in `plugin.xml`
- Updated all user-facing strings in `AndroidViewBundle.properties`
- Updated documentation files (README.md, CONTRIBUTING.md)
- Updated project configuration files (settings.gradle.kts, .idea/.name)
- Updated code comments in Kotlin files

## Test Plan
- [x] Build succeeds
- [x] Plugin name displays correctly in IDE settings
- [x] All references updated consistently

## Notes
This is a **display name only** change. The plugin ID (`com.z8dn.plugins.a2pt`) remains unchanged, so existing users will continue to receive updates without any issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed project from "Advanced Android Project View" to "Advanced Android Project Tree" across all user-facing elements, including plugin name, settings descriptions, and marketplace references.

* **Documentation**
  * Updated README and contributing guidelines to reflect the new project name; added version 0.0.6 entry to changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->