### PR TITLE
Add CLAUDE.md with build commands and architecture overview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Advanced Android Project Tree (A2PT)** is an IntelliJ Platform plugin for Android Studio that enhances the Android Project View with customizable file grouping and build directory visibility.
+
+## Common Commands
+
+```bash
+./gradlew build              # Full build with all checks
+./gradlew buildPlugin        # Build the plugin distribution ZIP
+./gradlew runIde             # Run plugin in a development Android Studio instance
+./gradlew test               # Run unit tests
+./gradlew check              # Run all tests and code inspections
+./gradlew verifyPlugin       # Run plugin structure verification
+./gradlew runPluginVerifier  # Run plugin verification on targeted IDEs
+```
+
+## Architecture
+
+The plugin intercepts IntelliJ's project tree via extension points and injects custom nodes.
+
+**Package:** `com.z8dn.plugins.a2pt`
+
+### Key Extension Points (registered in `plugin.xml`)
+- `treeStructureProvider` — intercepts and modifies the Android Project View tree
+- `androidViewNodeProvider` — extends Android module nodes with custom children
+- `applicationService` — `AndroidViewSettings` for persistent state
+- `applicationConfigurable` — settings UI under Tools menu
+- `postStartupActivity` — refreshes view on project open
+- `searchScopesProvider` — exposes file groups as Find/Replace scopes
+
+### Source Layout
+- `actions/` — toggle actions for build dir and module-level file display
+- `nodes/` — custom tree node classes (`ProjectFileGroupNode`, `ProjectFileNode`, `GradleModuleWithProjectFiles`)
+- `providers/` — tree structure providers that inject nodes (`AdvancedAndroidViewProvider`, `CustomNonAndroidNodeProvider`, `ProjectFilesTreeStructureProvider`)
+- `settings/` — `AndroidViewSettings` (PersistentStateComponent), configurable UI, and group dialog
+- `scopes/` — `ProjectFileGroupScopeProvider` for search scope integration
+- `utils/` — file matching (`AndroidViewNodeUtils`) and display formatting (`ProjectFileDisplayUtils`)
+
+### Data Flow
+1. User toggles features via actions → stored in `AndroidViewSettings` (persisted as `androidViewSettings.xml`)
+2. Tree providers read settings and intercept the tree to inject custom nodes
+3. File matching uses glob patterns and case-insensitive matching via `PatternMatcher`
+4. Two display modes: files under each module (`showProjectFilesInModule=true`) or grouped at project root
+
+### Key Settings
+- `showBuildDirectory` — show/hide `build/` directories in the tree
+- `showProjectFilesInModule` — toggle between module-level and project-root grouping
+- `projectFileGroups` — list of `ProjectFileGroup` objects (name + glob patterns)
+
+## Dependencies & Compatibility
+- Kotlin 2.3.0, JDK 21
+- IntelliJ Platform Gradle Plugin 2.10.5
+- Target: Android Studio Otter 3 Feature Drop (2025.2.3.9) and later
+- Bundled plugins used: `com.intellij.gradle`, `org.jetbrains.android`, `com.intellij.java`
+- No external runtime dependencies
+
+## Commit Conventions
+Follow Conventional Commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to help Claude Code understand the repository structure and operate effectively in future sessions.

## What changed

The file covers:
- **Common Gradle commands** — build, test, run, verify
- **Architecture overview** — how the plugin's extension points, providers, nodes, and settings connect
- **Data flow** — from user toggle actions through settings persistence to tree injection
- **Compatibility** — target IDE versions, Kotlin/JDK versions, bundled plugin dependencies
- **Commit conventions** — Conventional Commits format used in this repo

## Why

`CLAUDE.md` is loaded automatically by Claude Code at the start of each session, giving it the context needed to make accurate suggestions without re-exploring the codebase from scratch each time.

## Reviewer notes

This is a documentation-only change with no effect on plugin behavior or build output.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive repository documentation to guide development and contribution practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->