### PR TITLE
feat: add exclusion patterns and path-based filtering (#32)

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
@@ -36,8 +36,10 @@ class ProjectFileGroupNode(
         val psiManager = PsiManager.getInstance(myProject)
 
         for (file in allProjectFiles) {
-            // Only include files that match this group's patterns
-            if (!matchesAnyPattern(file.name, fileGroup.patterns)) {
+            val relativePath = myProject.basePath
+                ?.let { file.path.removePrefix(it).trimStart('/') }
+                ?: file.name
+            if (!ProjectFileDisplayUtils.matchesPatterns(file.name, relativePath, fileGroup.patterns)) {
                 continue
             }
 
@@ -58,43 +60,20 @@ class ProjectFileGroupNode(
         data.setIcon(getGroupIcon())
     }
 
-    /**
-     * Determines the icon for this group based on the patterns.
-     * - If there's only one pattern, use a file-type-specific icon
-     * - If there are multiple patterns, use a generic folder icon
-     */
     private fun getGroupIcon(): Icon {
-        if (fileGroup.patterns.size == 1) {
-            val pattern = fileGroup.patterns[0]
+        val inclusionPatterns = fileGroup.patterns.filter { !it.startsWith("!") }
+        if (inclusionPatterns.size == 1) {
+            val pattern = inclusionPatterns[0]
             val fileTypeManager = FileTypeManager.getInstance()
-
-            // Handle wildcard patterns like "*.md"
             if (pattern.startsWith("*.")) {
-                val extension = pattern.substring(2)
-                val fileType = fileTypeManager.getFileTypeByExtension(extension)
+                val fileType = fileTypeManager.getFileTypeByExtension(pattern.substring(2))
                 return fileType.icon ?: AllIcons.FileTypes.Text
             }
-
-            // Handle exact filename patterns like "LICENSE"
             if (!pattern.contains("*")) {
                 val fileType = fileTypeManager.getFileTypeByFileName(pattern)
                 return fileType.icon ?: AllIcons.FileTypes.Text
             }
         }
-
-        // Default to folder icon for multiple patterns or complex wildcards
         return AllIcons.Nodes.Folder
-    }
-
-    /**
-     * Checks if a filename matches any of the specified patterns.
-     */
-    private fun matchesAnyPattern(filename: String, patterns: List<String>): Boolean {
-        for (pattern in patterns) {
-            if (ProjectFileDisplayUtils.matchesPattern(filename, pattern)) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/scopes/ProjectFileGroupScope.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/scopes/ProjectFileGroupScope.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.search.scope.RangeBasedLocalSearchScope
 import com.z8dn.plugins.a2pt.AndroidViewBundle
 import com.z8dn.plugins.a2pt.settings.AndroidViewSettings
 import com.z8dn.plugins.a2pt.settings.ProjectFileGroup
+import com.z8dn.plugins.a2pt.utils.ProjectFileDisplayUtils
 import java.util.Objects
 
 /**
@@ -35,30 +36,18 @@ class ProjectFileGroupScope private constructor(
                 false
             )
         }
+    }
 
-        private fun matchesAnyFileGroup(file: VirtualFile): Boolean {
-            val settings = AndroidViewSettings.getInstance()
-            return settings.projectFileGroups.any { group ->
-                matchesFileGroup(file, group)
-            }
-        }
+    private fun matchesFileGroup(file: VirtualFile, fileGroup: ProjectFileGroup): Boolean {
+        val relativePath = myProject.basePath
+            ?.let { file.path.removePrefix(it).trimStart('/') }
+            ?: file.name
+        return ProjectFileDisplayUtils.matchesPatterns(file.name, relativePath, fileGroup.patterns)
+    }
 
-        private fun matchesFileGroup(file: VirtualFile, fileGroup: ProjectFileGroup): Boolean {
-            return fileGroup.patterns.any { pattern ->
-                matchesPattern(file, pattern)
-            }
-        }
-
-        private fun matchesPattern(file: VirtualFile, pattern: String): Boolean {
-            // Convert glob pattern to regex
-            val regexPattern = pattern
-                .replace(".", "\\.")
-                .replace("*", ".*")
-                .replace("?", ".")
-
-            val regex = Regex(regexPattern, RegexOption.IGNORE_CASE)
-            return regex.matches(file.name) || regex.containsMatchIn(file.path)
-        }
+    private fun matchesAnyFileGroup(file: VirtualFile): Boolean {
+        val settings = AndroidViewSettings.getInstance()
+        return settings.projectFileGroups.any { group -> matchesFileGroup(file, group) }
     }
 
     private val myVirtualFiles: Array<VirtualFile> by lazy {

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/scopes/ProjectFileGroupScope.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/scopes/ProjectFileGroupScope.kt
@@ -52,10 +52,10 @@ class ProjectFileGroupScope private constructor(
 
     private val myVirtualFiles: Array<VirtualFile> by lazy {
         val allFiles = mutableListOf<VirtualFile>()
-        // Collect files from project
-        if (fileGroup != null) {
+        val fg = fileGroup
+        if (fg != null) {
             // Child scope - filter by specific file group
-            collectFiles(myProject, allFiles) { file -> matchesFileGroup(file, fileGroup) }
+            collectFiles(myProject, allFiles) { file -> matchesFileGroup(file, fg) }
         } else {
             // Parent scope - all project file groups
             collectFiles(myProject, allFiles) { file -> matchesAnyFileGroup(file) }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -5,8 +5,6 @@ import com.z8dn.plugins.a2pt.settings.AndroidViewSettings
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.vfs.VirtualFile
-import java.nio.file.FileSystems
-import java.nio.file.PathMatcher
 
 /**
  * Utility functions for finding files and directories in Android Project View nodes.
@@ -17,41 +15,6 @@ import java.nio.file.PathMatcher
 object AndroidViewNodeUtils {
 
     private const val BUILD_DIRECTORY_NAME = "build"
-
-    /**
-     * Checks if a filename matches any of the specified patterns.
-     * Supports glob patterns (e.g., "*.md") and exact matches (case-insensitive).
-     *
-     * @param filename The filename to check
-     * @param patterns List of patterns to match against
-     * @return true if the filename matches any pattern
-     */
-    private fun matchesAnyPattern(filename: String, patterns: List<String>): Boolean {
-        val fileSystem = FileSystems.getDefault()
-        val filenameLower = filename.lowercase()
-
-        for (pattern in patterns) {
-            val patternLower = pattern.lowercase()
-
-            // Try glob pattern matching (case-insensitive)
-            try {
-                val matcher: PathMatcher = fileSystem.getPathMatcher("glob:$patternLower")
-                val path = fileSystem.getPath(filenameLower)
-                if (matcher.matches(path)) {
-                    return true
-                }
-            } catch (_: Exception) {
-                // If glob pattern fails, continue to next pattern
-            }
-
-            // Also check case-insensitive exact match
-            if (filenameLower == patternLower) {
-                return true
-            }
-        }
-
-        return false
-    }
 
     /**
      * Finds the build directory in the module's content roots.
@@ -92,10 +55,9 @@ object AndroidViewNodeUtils {
      */
     fun getAllProjectFilesInProject(project: com.intellij.openapi.project.Project): List<VirtualFile> {
         val settings = AndroidViewSettings.getInstance()
-        val allPatterns = settings.projectFileGroups.flatMap { it.patterns }
-        if (allPatterns.isEmpty()) return emptyList()
+        if (settings.projectFileGroups.isEmpty()) return emptyList()
 
-        val result = mutableListOf<VirtualFile>()
+        val result = mutableSetOf<VirtualFile>()
         val moduleManager = com.intellij.openapi.module.ModuleManager.getInstance(project)
 
         for (module in moduleManager.modules) {
@@ -104,13 +66,18 @@ object AndroidViewNodeUtils {
             val contentRoots = ModuleRootManager.getInstance(module).contentRoots
             for (root in contentRoots) {
                 for (child in root.children) {
-                    if (child.isValid && !child.isDirectory && matchesAnyPattern(child.name, allPatterns)) {
-                        result.add(child)
+                    if (!child.isValid || child.isDirectory) continue
+                    val relativePath = child.path.removePrefix(root.path).trimStart('/')
+                    for (group in settings.projectFileGroups) {
+                        if (ProjectFileDisplayUtils.matchesPatterns(child.name, relativePath, group.patterns)) {
+                            result.add(child)
+                            break
+                        }
                     }
                 }
             }
         }
 
-        return result
+        return result.toList()
     }
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
@@ -41,31 +41,40 @@ object ProjectFileDisplayUtils {
         return projectDisplayName
     }
 
-    /**
-     * Checks if a filename matches a pattern (glob or exact match).
-     * Matching is case-insensitive.
-     *
-     * @param filename The filename to check
-     * @param pattern The pattern to match against (supports glob patterns like *.md)
-     * @return true if the filename matches the pattern
-     */
-    fun matchesPattern(filename: String, pattern: String): Boolean {
-        val filenameLower = filename.lowercase()
+    private fun globMatches(input: String, pattern: String): Boolean {
+        val inputLower = input.lowercase().replace('\\', '/')
         val patternLower = pattern.lowercase()
-
-        // Try glob pattern matching
-        try {
-            val matcher = java.nio.file.FileSystems.getDefault()
-                .getPathMatcher("glob:$patternLower")
-            val path = java.nio.file.FileSystems.getDefault().getPath(filenameLower)
-            if (matcher.matches(path)) {
-                return true
-            }
+        return try {
+            val fs = java.nio.file.FileSystems.getDefault()
+            fs.getPathMatcher("glob:$patternLower").matches(fs.getPath(inputLower))
         } catch (_: Exception) {
-            // Fall through to exact match
+            inputLower == patternLower
         }
+    }
 
-        // Exact match
-        return filenameLower == patternLower
+    fun matchesPattern(filename: String, pattern: String): Boolean {
+        if (pattern.startsWith("!")) return false
+        return globMatches(filename, pattern)
+    }
+
+    /**
+     * Returns true if [filename]/[relativePath] should be included by [patterns].
+     * Gitignore semantics: included if matches any inclusion pattern and no exclusion pattern.
+     * Exclusion patterns are prefixed with `!` (e.g. `!archive/*.md`).
+     * Path patterns (e.g. `docs/*.txt`) are matched against [relativePath].
+     */
+    fun matchesPatterns(filename: String, relativePath: String, patterns: List<String>): Boolean {
+        var included = false
+        for (pattern in patterns) {
+            if (pattern.startsWith("!")) {
+                val p = pattern.removePrefix("!")
+                if (globMatches(filename, p) || globMatches(relativePath, p)) return false
+            } else {
+                if (!included && (globMatches(filename, pattern) || globMatches(relativePath, pattern))) {
+                    included = true
+                }
+            }
+        }
+        return included
     }
 }

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -9,7 +9,7 @@ settings.DisplayName.text=Advanced Android Project Tree
 settings.ShowBuildDirectory.text=Show build directory
 settings.ShowBuildDirectory.description=Show the build directory in Android modules
 settings.CustomFileGroups.text=Custom File Groups
-settings.CustomFileGroups.description=Each group can contain multiple file patterns (e.g., *.md, LICENSE, README.md)
+settings.CustomFileGroups.description=Each group can contain multiple file patterns. Prefix with ! to exclude (e.g. !archive/*.md).
 settings.Table.ColumnName.groupName=Group Name
 settings.Table.ColumnName.patterns=Patterns
 
@@ -18,11 +18,11 @@ dialog.ProjectFileGroup.Add.text=Add Custom File Group
 dialog.ProjectFileGroup.Edit.text=Edit Custom File Group
 dialog.ProjectFileGroup.GroupName.text=Group name:
 dialog.ProjectFileGroup.Patterns.text=File patterns:
-dialog.ProjectFileGroup.Patterns.description=Examples: *.md, LICENSE, README.md, *.txt, .gitignore
+dialog.ProjectFileGroup.Patterns.description=Examples: *.md, LICENSE, docs/*.txt — Exclusion: !archive/*.md
 dialog.ProjectFileGroup.Table.ColumnName.text=Pattern
 dialog.AddPattern.text=Add Pattern
-dialog.AddPattern.description=Enter a file pattern:
-dialog.EditPattern.description=Edit file pattern:
+dialog.AddPattern.description=Enter a file pattern (e.g. *.md, docs/*.txt, !archive/*.md):
+dialog.EditPattern.description=Edit file pattern (e.g. *.md, docs/*.txt, !archive/*.md):
 dialog.Validation.GroupNameEmpty.text=Group name cannot be empty
 dialog.Validation.PatternsEmpty.text=At least one pattern is required
 


### PR DESCRIPTION
Add support for exclusion patterns (!archive/*.md) and path-relative glob
matching in file group filters. All three matchers now share a single
matchesPatterns() implementation with gitignore semantics: a file is
included if it matches any inclusion pattern and no exclusion pattern.
Pattern evaluation uses relative path from content root so patterns like
docs/*.txt work as expected.

https://claude.ai/code/session_01WRnCBCawbbhFvTuRUK5Lsg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exclusion patterns using `!` prefix in custom file groups to filter out specific files.

* **Improvements**
  * Enhanced file pattern matching to evaluate both filenames and project-relative paths for more accurate filtering.

* **Documentation**
  * Updated help text and examples to demonstrate the new exclusion pattern syntax and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->