### PR TITLE
Bump IntelliJ Platform plugin and standardize version catalog naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ The plugin intercepts IntelliJ's project tree via extension points and injects c
 
 ## Dependencies & Compatibility
 - Kotlin 2.3.0, JDK 21
-- IntelliJ Platform Gradle Plugin 2.10.5
+- IntelliJ Platform Gradle Plugin 2.14.0
 - Target: Android Studio Otter 3 Feature Drop (2025.2.3.9) and later
 - Bundled plugins used: `com.intellij.gradle`, `org.jetbrains.android`, `com.intellij.java`
 - No external runtime dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,9 +5,9 @@ import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 plugins {
     id("java") // Java support
     alias(libs.plugins.kotlin) // Kotlin support
-    alias(libs.plugins.intelliJPlatform) // IntelliJ Platform Gradle Plugin
+    alias(libs.plugins.intellij.platform) // IntelliJ Platform Gradle Plugin
     alias(libs.plugins.changelog) // Gradle Changelog Plugin
-    alias(libs.plugins.composeCompiler) // Gradle Compose Compiler Plugin
+    alias(libs.plugins.compose.compiler) // Gradle Compose Compiler Plugin
 }
 
 group = providers.gradleProperty("pluginGroup").get()
@@ -41,11 +41,11 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.opentest4j)
     testImplementation(libs.hamcrest)
-    testImplementation(libs.composeuitest)
-    testImplementation(libs.jewelstandalone)
+    testImplementation(libs.compose.ui.test)
+    testImplementation(libs.jewel.standalone)
     // Workaround for running tests on Windows and Linux
     // It provides necessary Skiko runtime native binaries
-    testImplementation(libs.skikoAwtRuntimeAll)
+    testImplementation(libs.skiko.awt.runtime.all)
 
     intellijPlatform {
         androidStudio(providers.gradleProperty("platformVersion"))

--- a/gradle/CLAUDE.md
+++ b/gradle/CLAUDE.md
@@ -1,0 +1,3 @@
+# Version Catalog Naming
+
+In `libs.versions.toml`, use **camelCase** for version keys and **kebab-case** for library and plugin aliases.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,26 +4,26 @@ junit = "4.13.2"
 opentest4j = "1.3.0"
 hamcrest = "2.2"
 # Has to be in sync with IntelliJ Platform
-composeuitest = "1.10.0-alpha01"
-jewelstandalone = "0.32.1-253.28294.285"
+composeUiTest = "1.10.0-alpha01"
+jewelStandalone = "0.32.1-253.28294.285"
 skikoAwtRuntimeAll = "0.9.24"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.10.5"
+intellijPlatform = "2.14.0"
 kotlin = "2.3.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 opentest4j = { group = "org.opentest4j", name = "opentest4j", version.ref = "opentest4j" }
 hamcrest = { group = "org.hamcrest", name = "hamcrest", version.ref = "hamcrest" }
-composeuitest = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4-desktop", version.ref = "composeuitest" }
-jewelstandalone = { group = "org.jetbrains.jewel", name = "jewel-int-ui-standalone", version.ref = "jewelstandalone" }
-skikoAwtRuntimeAll = { group = "org.jetbrains.skiko", name = "skiko-awt-runtime-all", version.ref = "skikoAwtRuntimeAll" }
+compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4-desktop", version.ref = "composeUiTest" }
+jewel-standalone = { group = "org.jetbrains.jewel", name = "jewel-int-ui-standalone", version.ref = "jewelStandalone" }
+skiko-awt-runtime-all = { group = "org.jetbrains.skiko", name = "skiko-awt-runtime-all", version.ref = "skikoAwtRuntimeAll" }
 
 
 [plugins]
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
-intelliJPlatform = { id = "org.jetbrains.intellij.platform", version.ref = "intelliJPlatform" }
+intellij-platform = { id = "org.jetbrains.intellij.platform", version.ref = "intellijPlatform" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Bump IntelliJ Platform Gradle Plugin from 2.10.5 to 2.14.0
- Bump Gradle wrapper from 8.14.3 to 9.4.1
- Standardize version catalog naming: camelCase for versions, kebab-case for library/plugin aliases
- Add `gradle/CLAUDE.md` documenting the naming convention

## Test plan
- [ ] Verify `./gradlew build` succeeds
- [ ] Verify `./gradlew runIde` launches correctly
- [ ] Verify plugin loads in development IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradle build system to version 9.4.1.
  * Updated build dependencies and plugin aliases to align with new naming conventions.

* **Documentation**
  * Added Gradle Version Catalog guidelines documentation.
  * Updated compatibility documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->