### PR TITLE
Upgrade pluginSinceBuild to 261 (Android Studio Quail 1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ pluginRepositoryUrl = https://github.com/z8dn/advanced-android-project-view
 pluginVersion = 0.0.8
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 252
+pluginSinceBuild = 261
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
-# Android Studio Otter 3 Feature Drop - Stable (Released Jan 15, 2026)
-platformVersion = 2025.2.3.9
+# Android Studio Quail 1 | 2026.1.1 Canary 1 (Released Apr 16, 2026)
+platformVersion = 2026.1.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION
## Summary
- Bump `pluginSinceBuild` from 252 to 261
- Bump `platformVersion` from 2025.2.3.9 (Otter 3) to 2026.1.1.1 (Quail 1 Canary 1)
- Targets the IntelliJ 2026.1 platform

## Test plan
- [x] `./gradlew build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin's minimum required IntelliJ Platform version and upgraded the target platform version to support newer IDE releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->