### PR TITLE
feat: add exclusion patterns and path-based glob matching

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
@@ -23,7 +23,7 @@ class ProjectFileGroupNode(
     private val myProject: Project,
     private val settings: ViewSettings,
     private val fileGroup: ProjectFileGroup,
-    private val allProjectFiles: List<VirtualFile>
+    private val allProjectFiles: List<Pair<VirtualFile, String>>
 ) : AbstractTreeNode<String>(myProject, fileGroup.groupName) {
 
     override fun getChildren(): Collection<AbstractTreeNode<*>> {
@@ -35,9 +35,9 @@ class ProjectFileGroupNode(
         val result = mutableListOf<AbstractTreeNode<*>>()
         val psiManager = PsiManager.getInstance(myProject)
 
-        for (file in allProjectFiles) {
+        for ((file, relativePath) in allProjectFiles) {
             // Only include files that match this group's patterns
-            if (!matchesAnyPattern(file.name, fileGroup.patterns)) {
+            if (!AndroidViewNodeUtils.matchesPatterns(file.name, relativePath, fileGroup.patterns)) {
                 continue
             }
 
@@ -60,12 +60,13 @@ class ProjectFileGroupNode(
 
     /**
      * Determines the icon for this group based on the patterns.
-     * - If there's only one pattern, use a file-type-specific icon
-     * - If there are multiple patterns, use a generic folder icon
+     * - If there's only one non-exclusion pattern, use a file-type-specific icon
+     * - Otherwise, use a generic folder icon
      */
     private fun getGroupIcon(): Icon {
-        if (fileGroup.patterns.size == 1) {
-            val pattern = fileGroup.patterns[0]
+        val inclusionPatterns = fileGroup.patterns.filter { !it.startsWith("!") }
+        if (inclusionPatterns.size == 1) {
+            val pattern = inclusionPatterns[0]
             val fileTypeManager = FileTypeManager.getInstance()
 
             // Handle wildcard patterns like "*.md"
@@ -76,7 +77,7 @@ class ProjectFileGroupNode(
             }
 
             // Handle exact filename patterns like "LICENSE"
-            if (!pattern.contains("*")) {
+            if (!pattern.contains("*") && !pattern.contains("/")) {
                 val fileType = fileTypeManager.getFileTypeByFileName(pattern)
                 return fileType.icon ?: AllIcons.FileTypes.Text
             }
@@ -84,17 +85,5 @@ class ProjectFileGroupNode(
 
         // Default to folder icon for multiple patterns or complex wildcards
         return AllIcons.Nodes.Folder
-    }
-
-    /**
-     * Checks if a filename matches any of the specified patterns.
-     */
-    private fun matchesAnyPattern(filename: String, patterns: List<String>): Boolean {
-        for (pattern in patterns) {
-            if (ProjectFileDisplayUtils.matchesPattern(filename, pattern)) {
-                return true
-            }
-        }
-        return false
     }
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/providers/AdvancedAndroidViewProvider.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/providers/AdvancedAndroidViewProvider.kt
@@ -99,14 +99,12 @@ class AdvancedAndroidViewProvider : AndroidViewNodeProvider {
      * @return List of project files (VirtualFile) belonging to this module
      */
     private fun getProjectFiles(module: Module): List<VirtualFile> {
-        val allProjectFiles = AndroidViewNodeUtils.getAllProjectFilesInProject(module.project)
-        return allProjectFiles.filter {
-            ModuleUtilCore.moduleContainsFile(module, it, true) || ModuleUtilCore.moduleContainsFile(
-                module,
-                it,
-                false
-            )
-        }
+        return AndroidViewNodeUtils.getAllProjectFilesInProject(module.project)
+            .filter { (file, _) ->
+                ModuleUtilCore.moduleContainsFile(module, file, true) ||
+                ModuleUtilCore.moduleContainsFile(module, file, false)
+            }
+            .map { (file, _) -> file }
     }
 
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/providers/CustomNonAndroidNodeProvider.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/providers/CustomNonAndroidNodeProvider.kt
@@ -60,10 +60,11 @@ class CustomNonAndroidNodeProvider : TreeStructureProvider {
      * Filters project files from the entire project to those contained in this module.
      */
     private fun getProjectFiles(module: Module): List<VirtualFile> {
-        val allProjectFiles = AndroidViewNodeUtils.getAllProjectFilesInProject(module.project)
-        return allProjectFiles.filter {
-            ModuleUtilCore.moduleContainsFile(module, it, true) ||
-            ModuleUtilCore.moduleContainsFile(module, it, false)
-        }
+        return AndroidViewNodeUtils.getAllProjectFilesInProject(module.project)
+            .filter { (file, _) ->
+                ModuleUtilCore.moduleContainsFile(module, file, true) ||
+                ModuleUtilCore.moduleContainsFile(module, file, false)
+            }
+            .map { (file, _) -> file }
     }
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/settings/ProjectFileGroupDialog.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/settings/ProjectFileGroupDialog.kt
@@ -138,8 +138,13 @@ class ProjectFileGroupDialog(
             return ValidationInfo(AndroidViewBundle.message("dialog.Validation.GroupNameEmpty.text"), groupNameField)
         }
 
-        if (patternsTableModel.getPatterns().isEmpty()) {
+        val patterns = patternsTableModel.getPatterns()
+        if (patterns.isEmpty()) {
             return ValidationInfo(AndroidViewBundle.message("dialog.Validation.PatternsEmpty.text"), patternsTable)
+        }
+
+        if (patterns.all { it.startsWith("!") }) {
+            return ValidationInfo(AndroidViewBundle.message("dialog.Validation.NoInclusionPattern.text"), patternsTable)
         }
 
         return null

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -4,9 +4,12 @@ import com.z8dn.plugins.a2pt.settings.AndroidViewSettings
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VfsUtil
 import java.nio.file.FileSystems
 import java.nio.file.PathMatcher
+import java.nio.file.Paths
 
 /**
  * Utility functions for finding files and directories in Android Project View nodes.
@@ -19,38 +22,48 @@ object AndroidViewNodeUtils {
     private const val BUILD_DIRECTORY_NAME = "build"
 
     /**
-     * Checks if a filename matches any of the specified patterns.
-     * Supports glob patterns (e.g., "*.md") and exact matches (case-insensitive).
+     * Checks whether a file should be included based on a list of patterns.
+     * Patterns prefixed with ! are exclusions. Patterns containing / are matched
+     * against the relative path; others match the filename only.
+     * A file is included when it matches at least one inclusion pattern AND
+     * does not match any exclusion pattern.
      *
-     * @param filename The filename to check
-     * @param patterns List of patterns to match against
-     * @return true if the filename matches any pattern
+     * @param fileName     The bare filename
+     * @param relativePath The file path relative to the project root
+     * @param patterns     List of patterns (may include !-prefixed exclusions)
+     * @return true if the file should be included
      */
-    private fun matchesAnyPattern(filename: String, patterns: List<String>): Boolean {
-        val fileSystem = FileSystems.getDefault()
-        val filenameLower = filename.lowercase()
+    fun matchesPatterns(fileName: String, relativePath: String, patterns: List<String>): Boolean {
+        val exclusions = patterns.filter { it.startsWith("!") }.map { it.removePrefix("!") }
+        val inclusions = patterns.filter { !it.startsWith("!") }
 
-        for (pattern in patterns) {
-            val patternLower = pattern.lowercase()
+        val included = inclusions.isEmpty() || inclusions.any { matchSingle(it, fileName, relativePath) }
+        val excluded = exclusions.any { matchSingle(it, fileName, relativePath) }
+        return included && !excluded
+    }
 
-            // Try glob pattern matching (case-insensitive)
-            try {
-                val matcher: PathMatcher = fileSystem.getPathMatcher("glob:$patternLower")
-                val path = fileSystem.getPath(filenameLower)
-                if (matcher.matches(path)) {
-                    return true
-                }
-            } catch (_: Exception) {
-                // If glob pattern fails, continue to next pattern
-            }
-
-            // Also check case-insensitive exact match
-            if (filenameLower == patternLower) {
-                return true
-            }
+    /**
+     * Matches a single pattern against a file. Patterns containing `/` are matched
+     * against [relativePath]; all others are matched against [fileName].
+     */
+    private fun matchSingle(pattern: String, fileName: String, relativePath: String): Boolean {
+        val patternLower = pattern.lowercase()
+        return if ('/' in patternLower) {
+            matchGlob(patternLower, relativePath.lowercase()) ||
+                patternLower == relativePath.lowercase()
+        } else {
+            matchGlob(patternLower, fileName.lowercase()) ||
+                patternLower == fileName.lowercase()
         }
+    }
 
-        return false
+    private fun matchGlob(pattern: String, target: String): Boolean {
+        return try {
+            val matcher: PathMatcher = FileSystems.getDefault().getPathMatcher("glob:$pattern")
+            matcher.matches(Paths.get(target))
+        } catch (_: Exception) {
+            false
+        }
     }
 
     /**
@@ -85,17 +98,19 @@ object AndroidViewNodeUtils {
     /**
      * Gets all project files from the entire project that match configured patterns.
      * Searches all module content roots in the project.
-     * This is analogous to getting all build files from the project system.
      *
      * @param project The project to search in
-     * @return List of all matching VirtualFiles across all modules
+     * @return List of (VirtualFile, relativePath) pairs for all matching files
      */
-    fun getAllProjectFilesInProject(project: com.intellij.openapi.project.Project): List<VirtualFile> {
+    fun getAllProjectFilesInProject(project: com.intellij.openapi.project.Project): List<Pair<VirtualFile, String>> {
         val settings = AndroidViewSettings.getInstance()
         val allPatterns = settings.projectFileGroups.flatMap { it.patterns }
         if (allPatterns.isEmpty()) return emptyList()
 
-        val result = mutableListOf<VirtualFile>()
+        val projectBaseDir = project.basePath
+            ?.let { LocalFileSystem.getInstance().findFileByPath(it) }
+            ?: return emptyList()
+        val result = mutableListOf<Pair<VirtualFile, String>>()
         val moduleManager = com.intellij.openapi.module.ModuleManager.getInstance(project)
 
         for (module in moduleManager.modules) {
@@ -104,8 +119,11 @@ object AndroidViewNodeUtils {
             val contentRoots = ModuleRootManager.getInstance(module).contentRoots
             for (root in contentRoots) {
                 for (child in root.children) {
-                    if (child.isValid && !child.isDirectory && matchesAnyPattern(child.name, allPatterns)) {
-                        result.add(child)
+                    if (child.isValid && !child.isDirectory) {
+                        val relativePath = VfsUtil.getRelativePath(child, projectBaseDir, '/') ?: child.name
+                        if (matchesPatterns(child.name, relativePath, allPatterns)) {
+                            result.add(child to relativePath)
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
@@ -41,31 +41,4 @@ object ProjectFileDisplayUtils {
         return projectDisplayName
     }
 
-    /**
-     * Checks if a filename matches a pattern (glob or exact match).
-     * Matching is case-insensitive.
-     *
-     * @param filename The filename to check
-     * @param pattern The pattern to match against (supports glob patterns like *.md)
-     * @return true if the filename matches the pattern
-     */
-    fun matchesPattern(filename: String, pattern: String): Boolean {
-        val filenameLower = filename.lowercase()
-        val patternLower = pattern.lowercase()
-
-        // Try glob pattern matching
-        try {
-            val matcher = java.nio.file.FileSystems.getDefault()
-                .getPathMatcher("glob:$patternLower")
-            val path = java.nio.file.FileSystems.getDefault().getPath(filenameLower)
-            if (matcher.matches(path)) {
-                return true
-            }
-        } catch (_: Exception) {
-            // Fall through to exact match
-        }
-
-        // Exact match
-        return filenameLower == patternLower
-    }
 }

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -9,7 +9,7 @@ settings.DisplayName.text=Advanced Android Project Tree
 settings.ShowBuildDirectory.text=Show build directory
 settings.ShowBuildDirectory.description=Show the build directory in Android modules
 settings.CustomFileGroups.text=Custom File Groups
-settings.CustomFileGroups.description=Each group can contain multiple file patterns (e.g., *.md, LICENSE, README.md)
+settings.CustomFileGroups.description=Each group can contain multiple file patterns (e.g., *.md, LICENSE, README.md). Use ! to exclude files (e.g., !archive/*.md).
 settings.Table.ColumnName.groupName=Group Name
 settings.Table.ColumnName.patterns=Patterns
 
@@ -18,13 +18,14 @@ dialog.ProjectFileGroup.Add.text=Add Custom File Group
 dialog.ProjectFileGroup.Edit.text=Edit Custom File Group
 dialog.ProjectFileGroup.GroupName.text=Group name:
 dialog.ProjectFileGroup.Patterns.text=File patterns:
-dialog.ProjectFileGroup.Patterns.description=Examples: *.md, LICENSE, README.md, *.txt, .gitignore
+dialog.ProjectFileGroup.Patterns.description=Include: *.md, LICENSE, docs/*.md  |  Exclude (prefix !): !archive/*.md, !*.draft
 dialog.ProjectFileGroup.Table.ColumnName.text=Pattern
 dialog.AddPattern.text=Add Pattern
-dialog.AddPattern.description=Enter a file pattern:
+dialog.AddPattern.description=Enter a file pattern (prefix with ! to exclude, e.g. !archive/*.md):
 dialog.EditPattern.description=Edit file pattern:
 dialog.Validation.GroupNameEmpty.text=Group name cannot be empty
 dialog.Validation.PatternsEmpty.text=At least one pattern is required
+dialog.Validation.NoInclusionPattern.text=At least one inclusion pattern (without !) is required
 
 # Search Scope
 scope.ProjectFileGroups.DisplayName=Project File Groups

--- a/src/test/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtilsTest.kt
+++ b/src/test/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtilsTest.kt
@@ -1,0 +1,103 @@
+package com.z8dn.plugins.a2pt.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AndroidViewNodeUtilsTest {
+
+    // region backward compatibility
+
+    @Test
+    fun `glob pattern matches by filename`() {
+        assertTrue(match("README.md", "README.md", listOf("*.md")))
+    }
+
+    @Test
+    fun `glob pattern is case-insensitive`() {
+        assertTrue(match("README.MD", "README.MD", listOf("*.md")))
+    }
+
+    @Test
+    fun `exact filename match`() {
+        assertTrue(match("LICENSE", "LICENSE", listOf("LICENSE")))
+    }
+
+    @Test
+    fun `non-matching filename returns false`() {
+        assertFalse(match("build.gradle.kts", "build.gradle.kts", listOf("*.md")))
+    }
+
+    // endregion
+
+    // region path-based patterns
+
+    @Test
+    fun `path pattern matches file in correct directory`() {
+        assertTrue(match("guide.md", "docs/guide.md", listOf("docs/*.md")))
+    }
+
+    @Test
+    fun `path pattern does not match file in wrong directory`() {
+        assertFalse(match("guide.md", "archive/guide.md", listOf("docs/*.md")))
+    }
+
+    @Test
+    fun `path pattern does not match root-level file`() {
+        assertFalse(match("guide.md", "guide.md", listOf("docs/*.md")))
+    }
+
+    // endregion
+
+    // region exclusion patterns
+
+    @Test
+    fun `exclusion pattern removes matching file`() {
+        assertFalse(match("notes.md", "archive/notes.md", listOf("*.md", "!archive/*.md")))
+    }
+
+    @Test
+    fun `exclusion pattern does not affect non-matching file`() {
+        assertTrue(match("guide.md", "docs/guide.md", listOf("*.md", "!archive/*.md")))
+    }
+
+    @Test
+    fun `filename exclusion removes file regardless of directory`() {
+        assertFalse(match("claude.md", "claude.md", listOf("*.md", "!claude.md")))
+    }
+
+    @Test
+    fun `filename exclusion does not affect other md files`() {
+        assertTrue(match("README.md", "README.md", listOf("*.md", "!claude.md")))
+    }
+
+    @Test
+    fun `exclusion without inclusion includes nothing`() {
+        // inclusions is empty -> included = true, but then excluded by !*.md
+        assertFalse(match("README.md", "README.md", listOf("!*.md")))
+    }
+
+    // endregion
+
+    // region multiple patterns
+
+    @Test
+    fun `multiple inclusions match any`() {
+        assertTrue(match("LICENSE", "LICENSE", listOf("*.md", "LICENSE")))
+        assertTrue(match("README.md", "README.md", listOf("*.md", "LICENSE")))
+    }
+
+    @Test
+    fun `inclusion and path-based exclusion combined`() {
+        val patterns = listOf("*.md", "!archive/*.md")
+        assertTrue(match("README.md", "README.md", patterns))
+        assertTrue(match("guide.md", "docs/guide.md", patterns))
+        assertFalse(match("notes.md", "archive/notes.md", patterns))
+    }
+
+    // endregion
+
+    private fun match(fileName: String, relativePath: String, patterns: List<String>): Boolean {
+        return AndroidViewNodeUtils.matchesPatterns(fileName, relativePath, patterns)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `!` prefix syntax for exclusion patterns (e.g. `!archive/*.md` excludes markdown files inside `archive/`)
- Patterns containing `/` are now matched against the file's relative path from the project root, enabling path-based filtering (e.g. `docs/*.md`)
- Centralizes and deduplicates matching logic into `AndroidViewNodeUtils.matchesPatterns()`, removing the copy in `ProjectFileDisplayUtils`
- Validates that each group has at least one inclusion pattern (not all `!`-prefixed)
- Updates dialog and settings help text to document the new syntax

Closes #32

## Test plan

- [ ] Create a file group with `*.md` and `!archive/*.md` — markdown files in `archive/` should be excluded from the group
- [ ] Create a file group with `docs/*.md` — only markdown files inside `docs/` should appear
- [ ] Verify existing glob patterns (e.g. `*.md`, `LICENSE`) still work as before
- [ ] Confirm validation error appears when all patterns in a group start with `!`
- [ ] Run `./gradlew check verifyPlugin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File pattern matching now supports exclusion patterns using `!` and can match against relative file paths as well as filenames.

* **Improvements**
  * Dialog validation now requires at least one inclusion pattern.
  * Icon selection refined for clearer group icons based on pattern specificity.

* **Documentation**
  * Updated help text and descriptions to explain pattern syntax and exclusion semantics.

* **Tests**
  * Added unit tests covering inclusion, exclusion, path-based, and case-insensitive pattern behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->