### PR TITLE
feat: extend path filter to non-Gradle-module folders

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/nodes/ProjectFileGroupNode.kt
@@ -43,10 +43,13 @@ class ProjectFileGroupNode(
 
             val psiFile = psiManager.findFile(file) ?: continue
 
-            // Find which module contains this file using efficient lookup
-            val module = ModuleUtilCore.findModuleForFile(file, myProject) ?: continue
-
-            val qualifier = ProjectFileDisplayUtils.generateDisplayName(file, module)
+            // Find which module contains this file (may be null for non-module folders)
+            val module = ModuleUtilCore.findModuleForFile(file, myProject)
+            val qualifier = if (module != null) {
+                ProjectFileDisplayUtils.generateDisplayName(file, module)
+            } else {
+                file.parent?.name ?: relativePath
+            }
             result.add(ProjectFileNode(myProject, psiFile, settings, qualifier, 10))
         }
 

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -196,7 +196,9 @@ object AndroidViewNodeUtils {
         for (child in dir.children) {
             if (!child.isValid) continue
             if (child.isDirectory) {
-                scanDirectoryForFiles(child, projectBaseDir, patterns, result)
+                if (child.name !in IGNORED_SCAN_DIRECTORIES) {
+                    scanDirectoryForFiles(child, projectBaseDir, patterns, result)
+                }
             } else {
                 val relativePath = VfsUtil.getRelativePath(child, projectBaseDir, '/') ?: child.name
                 if (matchesPatterns(child.name, relativePath, patterns)) {
@@ -205,4 +207,8 @@ object AndroidViewNodeUtils {
             }
         }
     }
+
+    private val IGNORED_SCAN_DIRECTORIES = setOf(
+        BUILD_DIRECTORY_NAME, ".git", ".gradle", ".idea", "node_modules"
+    )
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -97,7 +97,8 @@ object AndroidViewNodeUtils {
 
     /**
      * Gets all project files from the entire project that match configured patterns.
-     * Searches all module content roots in the project.
+     * Searches all module content roots, and also directly navigates to directories
+     * indicated by path-based patterns (to support non-Gradle-module folders).
      *
      * @param project The project to search in
      * @return List of (VirtualFile, relativePath) pairs for all matching files
@@ -129,6 +130,79 @@ object AndroidViewNodeUtils {
             }
         }
 
+        // Also scan directories pointed to directly by path-based patterns.
+        // This handles non-Gradle-module folders (e.g. a top-level "docs/" folder).
+        val seenPaths = result.map { it.first.path }.toMutableSet()
+        for (entry in getFilesFromPathBasedPatterns(projectBaseDir, allPatterns)) {
+            if (seenPaths.add(entry.first.path)) {
+                result.add(entry)
+            }
+        }
+
         return result
+    }
+
+    /**
+     * For each path-based inclusion pattern (containing '/'), extracts the non-wildcard
+     * directory prefix and navigates there directly from [projectBaseDir], collecting all
+     * files that match the full pattern list. This is decoupled from the module scan.
+     *
+     * e.g. "docs/guide.md" or "docs/glob-pattern" → scans <project>/docs/ directly
+     *      "docs/sub/glob-pattern"                 → scans <project>/docs/sub/ directly
+     *      "docs/glob-recursive"                   → scans <project>/docs/ recursively
+     */
+    private fun getFilesFromPathBasedPatterns(
+        projectBaseDir: VirtualFile,
+        patterns: List<String>
+    ): List<Pair<VirtualFile, String>> {
+        val result = mutableListOf<Pair<VirtualFile, String>>()
+        val dirPrefixes = patterns
+            .filter { !it.startsWith("!") }
+            .mapNotNull { extractDirectoryPrefix(it) }
+            .toSet()
+        for (prefix in dirPrefixes) {
+            val targetDir = projectBaseDir.findFileByRelativePath(prefix) ?: continue
+            if (!targetDir.isValid || !targetDir.isDirectory) continue
+            scanDirectoryForFiles(targetDir, projectBaseDir, patterns, result)
+        }
+        return result
+    }
+
+    /**
+     * Extracts the non-wildcard directory prefix from a path-based pattern.
+     * Returns null for filename-only patterns (no '/') or patterns whose first
+     * directory segment contains a wildcard.
+     *
+     * e.g. "docs/guide.md"     → "docs"
+     *      "docs/sub/guide.md" → "docs/sub"
+     *      "docs/deep/glob"    → "docs"
+     *      "filename-only"     → null
+     *      "wildcard-dir/file" → null (when dir segment contains glob chars)
+     */
+    private fun extractDirectoryPrefix(pattern: String): String? {
+        if ('/' !in pattern) return null
+        val segments = pattern.split('/')
+        val dirSegments = segments.dropLast(1)
+        val prefix = dirSegments.takeWhile { '*' !in it && '?' !in it }
+        return if (prefix.isEmpty()) null else prefix.joinToString("/")
+    }
+
+    private fun scanDirectoryForFiles(
+        dir: VirtualFile,
+        projectBaseDir: VirtualFile,
+        patterns: List<String>,
+        result: MutableList<Pair<VirtualFile, String>>
+    ) {
+        for (child in dir.children) {
+            if (!child.isValid) continue
+            if (child.isDirectory) {
+                scanDirectoryForFiles(child, projectBaseDir, patterns, result)
+            } else {
+                val relativePath = VfsUtil.getRelativePath(child, projectBaseDir, '/') ?: child.name
+                if (matchesPatterns(child.name, relativePath, patterns)) {
+                    result.add(child to relativePath)
+                }
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -108,6 +108,11 @@ object AndroidViewNodeUtils {
         val allPatterns = settings.projectFileGroups.flatMap { it.patterns }
         if (allPatterns.isEmpty()) return emptyList()
 
+        // Use only inclusion patterns for global file discovery. Exclusions from one group
+        // must not prevent another group from showing the same file — per-group exclusions
+        // are applied later in ProjectFileGroupNode when each group filters this list.
+        val inclusionPatterns = allPatterns.filter { !it.startsWith("!") }
+
         val projectBaseDir = project.basePath
             ?.let { LocalFileSystem.getInstance().findFileByPath(it) }
             ?: return emptyList()
@@ -122,7 +127,7 @@ object AndroidViewNodeUtils {
                 for (child in root.children) {
                     if (child.isValid && !child.isDirectory) {
                         val relativePath = VfsUtil.getRelativePath(child, projectBaseDir, '/') ?: child.name
-                        if (matchesPatterns(child.name, relativePath, allPatterns)) {
+                        if (matchesPatterns(child.name, relativePath, inclusionPatterns)) {
                             result.add(child to relativePath)
                         }
                     }
@@ -132,9 +137,9 @@ object AndroidViewNodeUtils {
 
         // Also scan directories pointed to directly by path-based patterns.
         // This handles non-Gradle-module folders (e.g. a top-level "docs/" folder).
-        val seenPaths = result.map { it.first.path }.toMutableSet()
-        for (entry in getFilesFromPathBasedPatterns(projectBaseDir, allPatterns)) {
-            if (seenPaths.add(entry.first.path)) {
+        val seen = result.mapTo(HashSet()) { it.first }
+        for (entry in getFilesFromPathBasedPatterns(projectBaseDir, inclusionPatterns)) {
+            if (seen.add(entry.first)) {
                 result.add(entry)
             }
         }

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/AndroidViewNodeUtils.kt
@@ -161,11 +161,22 @@ object AndroidViewNodeUtils {
             .mapNotNull { extractDirectoryPrefix(it) }
             .toSet()
         for (prefix in dirPrefixes) {
-            val targetDir = projectBaseDir.findFileByRelativePath(prefix) ?: continue
+            val targetDir = resolveDirCaseInsensitive(projectBaseDir, prefix) ?: continue
             if (!targetDir.isValid || !targetDir.isDirectory) continue
             scanDirectoryForFiles(targetDir, projectBaseDir, patterns, result)
         }
         return result
+    }
+
+    private fun resolveDirCaseInsensitive(base: VirtualFile, relative: String): VirtualFile? {
+        var current = base
+        for (segment in relative.split('/')) {
+            if (segment.isEmpty()) continue
+            current = current.children.firstOrNull {
+                it.isDirectory && it.name.equals(segment, ignoreCase = true)
+            } ?: return null
+        }
+        return current
     }
 
     /**


### PR DESCRIPTION
## Summary

- Path-based patterns (e.g. `docs/*.md`) now match files in **any folder under the project root**, not just folders registered as Gradle modules
- For each path-based pattern, the directory prefix is extracted (e.g. `docs`) and navigated to directly — no full-tree scan, completely decoupled from the existing module scan
- `ProjectFileGroupNode` no longer silently drops files that have no owning Gradle module; falls back to the parent folder name as the qualifier

## Test plan

- [ ] Create a non-Gradle-module folder (e.g. `docs/`) at the project root with `.md` files
- [ ] Add a group with pattern `docs/*.md` in A2PT settings
- [ ] Verify files appear in the group node in the Android Project View (grouped mode)
- [ ] Verify patterns like `docs/sub/*.md` only match files in that subdirectory
- [ ] Verify exclusions (e.g. `!docs/private.md`) still suppress files
- [ ] Verify existing Gradle module file display is unchanged
- [ ] Run `./gradlew test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Files without associated modules are now displayed in the project file list.
  * Enhanced file scanning to include files matching project inclusion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->