### PR TITLE
feat: add right-click menu to include directory in file group

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
@@ -82,8 +82,8 @@ class IncludeDirectoryInGroupActionGroup : DefaultActionGroup() {
 private fun buildPattern(project: Project, dir: VirtualFile): String? {
     val base = project.basePath
         ?.let { LocalFileSystem.getInstance().findFileByPath(it) } ?: return null
-    val relPath = VfsUtil.getRelativePath(dir, base, '/') ?: dir.name
-    return "$relPath/**"
+    val relPath = VfsUtil.getRelativePath(dir, base, '/') ?: return null
+    return if (relPath.isEmpty()) "**" else "$relPath/**"
 }
 
 private fun refreshAllProjects() {

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
@@ -1,0 +1,106 @@
+package com.z8dn.plugins.a2pt.actions
+
+import com.z8dn.plugins.a2pt.settings.AndroidViewSettings
+import com.z8dn.plugins.a2pt.settings.ProjectFileGroup
+import com.z8dn.plugins.a2pt.settings.ProjectFileGroupDialog
+
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.actionSystem.Separator
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VfsUtil
+
+abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : DefaultActionGroup() {
+
+    override fun getChildren(e: AnActionEvent?): Array<AnAction> {
+        val event = e ?: return EMPTY_ARRAY
+        val project = event.project ?: return EMPTY_ARRAY
+        val dir = event.getData(CommonDataKeys.VIRTUAL_FILE)
+            ?.takeIf { it.isDirectory } ?: return EMPTY_ARRAY
+
+        val groups = AndroidViewSettings.getInstance().projectFileGroups
+        val actions = mutableListOf<AnAction>()
+
+        for (group in groups) {
+            actions.add(ApplyPatternAction(project, dir, group, isExclusion))
+        }
+
+        if (!isExclusion) {
+            if (groups.isNotEmpty()) actions.add(Separator.getInstance())
+            actions.add(CreateNewGroupAction(project, dir))
+        }
+
+        return actions.toTypedArray()
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val dir = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val isAndroidView = project != null &&
+            ProjectView.getInstance(project).currentViewId == "AndroidView"
+        val isDirectory = dir?.isDirectory == true
+        val hasGroups = AndroidViewSettings.getInstance().projectFileGroups.isNotEmpty()
+
+        e.presentation.isEnabledAndVisible = isAndroidView && isDirectory &&
+            (!isExclusion || hasGroups)
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    private class ApplyPatternAction(
+        private val project: Project,
+        private val dir: VirtualFile,
+        private val group: ProjectFileGroup,
+        private val isExclusion: Boolean
+    ) : AnAction(group.groupName) {
+
+        override fun actionPerformed(e: AnActionEvent) {
+            val pattern = buildPattern(project, dir, isExclusion) ?: return
+            group.patterns.add(pattern)
+            refreshAllProjects()
+        }
+
+        override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+    }
+
+    private class CreateNewGroupAction(
+        private val project: Project,
+        private val dir: VirtualFile
+    ) : AnAction("New Group...") {
+
+        override fun actionPerformed(e: AnActionEvent) {
+            val pattern = buildPattern(project, dir, false) ?: return
+            val prefilledGroup = ProjectFileGroup(dir.name, mutableListOf(pattern))
+            val dialog = ProjectFileGroupDialog(prefilledGroup)
+            if (dialog.showAndGet()) {
+                AndroidViewSettings.getInstance().projectFileGroups.add(dialog.getProjectFileGroup())
+                refreshAllProjects()
+            }
+        }
+
+        override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+    }
+}
+
+private fun buildPattern(project: Project, dir: VirtualFile, isExclusion: Boolean): String? {
+    val base = project.basePath
+        ?.let { LocalFileSystem.getInstance().findFileByPath(it) } ?: return null
+    val relPath = VfsUtil.getRelativePath(dir, base, '/') ?: dir.name
+    return if (isExclusion) "!$relPath/**" else "$relPath/**"
+}
+
+private fun refreshAllProjects() {
+    ProjectManager.getInstance().openProjects
+        .filter { !it.isDisposed }
+        .forEach { ProjectView.getInstance(it)?.refresh() }
+}
+
+class IncludeDirectoryInGroupActionGroup : DirectoryGroupActionGroup(false)
+class ExcludeDirectoryFromGroupActionGroup : DirectoryGroupActionGroup(true)

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
@@ -41,15 +41,11 @@ abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : Def
     }
 
     override fun update(e: AnActionEvent) {
-        val project = e.project
         val dir = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        val isAndroidView = project != null &&
-            ProjectView.getInstance(project).currentViewId == "AndroidView"
         val isDirectory = dir?.isDirectory == true
         val hasGroups = AndroidViewSettings.getInstance().projectFileGroups.isNotEmpty()
 
-        e.presentation.isEnabledAndVisible = isAndroidView && isDirectory &&
-            (!isExclusion || hasGroups)
+        e.presentation.isEnabledAndVisible = isDirectory && (!isExclusion || hasGroups)
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
@@ -17,7 +17,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VfsUtil
 
-abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : DefaultActionGroup() {
+class IncludeDirectoryInGroupActionGroup : DefaultActionGroup() {
 
     override fun getChildren(e: AnActionEvent?): Array<AnAction> {
         val event = e ?: return EMPTY_ARRAY
@@ -29,36 +29,30 @@ abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : Def
         val actions = mutableListOf<AnAction>()
 
         for (group in groups) {
-            actions.add(ApplyPatternAction(project, dir, group, isExclusion))
+            actions.add(AddToGroupAction(project, dir, group))
         }
 
-        if (!isExclusion) {
-            if (groups.isNotEmpty()) actions.add(Separator.getInstance())
-            actions.add(CreateNewGroupAction(project, dir))
-        }
+        if (groups.isNotEmpty()) actions.add(Separator.getInstance())
+        actions.add(CreateNewGroupAction(project, dir))
 
         return actions.toTypedArray()
     }
 
     override fun update(e: AnActionEvent) {
         val dir = e.getData(CommonDataKeys.VIRTUAL_FILE)
-        val isDirectory = dir?.isDirectory == true
-        val hasGroups = AndroidViewSettings.getInstance().projectFileGroups.isNotEmpty()
-
-        e.presentation.isEnabledAndVisible = isDirectory && (!isExclusion || hasGroups)
+        e.presentation.isEnabledAndVisible = dir?.isDirectory == true
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
-    private class ApplyPatternAction(
+    private class AddToGroupAction(
         private val project: Project,
         private val dir: VirtualFile,
-        private val group: ProjectFileGroup,
-        private val isExclusion: Boolean
+        private val group: ProjectFileGroup
     ) : AnAction(group.groupName) {
 
         override fun actionPerformed(e: AnActionEvent) {
-            val pattern = buildPattern(project, dir, isExclusion) ?: return
+            val pattern = buildPattern(project, dir) ?: return
             group.patterns.add(pattern)
             refreshAllProjects()
         }
@@ -72,7 +66,7 @@ abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : Def
     ) : AnAction("New Group...") {
 
         override fun actionPerformed(e: AnActionEvent) {
-            val pattern = buildPattern(project, dir, false) ?: return
+            val pattern = buildPattern(project, dir) ?: return
             val prefilledGroup = ProjectFileGroup(dir.name, mutableListOf(pattern))
             val dialog = ProjectFileGroupDialog(prefilledGroup)
             if (dialog.showAndGet()) {
@@ -85,11 +79,11 @@ abstract class DirectoryGroupActionGroup(private val isExclusion: Boolean) : Def
     }
 }
 
-private fun buildPattern(project: Project, dir: VirtualFile, isExclusion: Boolean): String? {
+private fun buildPattern(project: Project, dir: VirtualFile): String? {
     val base = project.basePath
         ?.let { LocalFileSystem.getInstance().findFileByPath(it) } ?: return null
     val relPath = VfsUtil.getRelativePath(dir, base, '/') ?: dir.name
-    return if (isExclusion) "!$relPath/**" else "$relPath/**"
+    return "$relPath/**"
 }
 
 private fun refreshAllProjects() {
@@ -97,6 +91,3 @@ private fun refreshAllProjects() {
         .filter { !it.isDisposed }
         .forEach { ProjectView.getInstance(it)?.refresh() }
 }
-
-class IncludeDirectoryInGroupActionGroup : DirectoryGroupActionGroup(false)
-class ExcludeDirectoryFromGroupActionGroup : DirectoryGroupActionGroup(true)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,19 @@
 
     <!-- Toggle Actions for Android View -->
     <actions>
+        <group id="com.z8dn.plugins.a2pt.IncludeDirectoryGroup"
+               class="com.z8dn.plugins.a2pt.actions.IncludeDirectoryInGroupActionGroup"
+               text="Include Directory in File Group"
+               popup="true">
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </group>
+        <group id="com.z8dn.plugins.a2pt.ExcludeDirectoryGroup"
+               class="com.z8dn.plugins.a2pt.actions.ExcludeDirectoryFromGroupActionGroup"
+               text="Exclude Directory from File Group"
+               popup="true">
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </group>
+
         <group id="com.z8dn.plugins.a2pt.AppearanceActions">
             <add-to-group group-id="ProjectView.ToolWindow.Appearance.Actions"
                           relative-to-action="ShowBuildFilesInModuleAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,13 +49,6 @@
                popup="true">
             <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </group>
-        <group id="com.z8dn.plugins.a2pt.ExcludeDirectoryGroup"
-               class="com.z8dn.plugins.a2pt.actions.ExcludeDirectoryFromGroupActionGroup"
-               text="Exclude Directory from File Group"
-               popup="true">
-            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
-        </group>
-
         <group id="com.z8dn.plugins.a2pt.AppearanceActions">
             <add-to-group group-id="ProjectView.ToolWindow.Appearance.Actions"
                           relative-to-action="ShowBuildFilesInModuleAction"


### PR DESCRIPTION
## Summary

- Right-clicking any directory in the Project view now shows **"Include Directory in File Group ▶"**
- Submenu lists all existing groups (clicking one adds `dirPath/**` to that group's patterns) plus a **"New Group..."** option that opens the group dialog pre-filled with the directory name and pattern
- Visible on directories in all project views; hidden on files

## Test plan

- [ ] Right-click a directory → "Include Directory in File Group ▶" appears
- [ ] Clicking an existing group adds `dirPath/**` to its patterns and refreshes the tree
- [ ] "New Group..." opens the group dialog pre-filled with the directory name and `dirPath/**` pattern
- [ ] Right-clicking a file does not show the menu item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Include Directory in File Group" context action to the project view. Users can now quickly add directories to existing file groups or create new file groups directly from the right-click menu, improving project organization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->