### PR TITLE
fix: externalize all hardcoded UI strings to i18n bundle

### DIFF
--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/CustomizeAndroidTreeViewAction.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/CustomizeAndroidTreeViewAction.kt
@@ -8,7 +8,13 @@ import com.z8dn.plugins.a2pt.AndroidViewBundle
 import org.jetbrains.annotations.ApiStatus.Internal
 
 @Internal
-class CustomizeAndroidTreeViewAction : DumbAwareAction(), AndroidViewAction {
+class CustomizeAndroidTreeViewAction : DumbAwareAction(
+    { AndroidViewBundle.message("action.ProjectView.CustomizeAndroidTreeViewAction.text") }
+), AndroidViewAction {
+    init {
+        templatePresentation.description =
+            AndroidViewBundle.message("action.ProjectView.CustomizeAndroidTreeViewAction.description")
+    }
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/actions/DirectoryGroupActionGroup.kt
@@ -1,5 +1,6 @@
 package com.z8dn.plugins.a2pt.actions
 
+import com.z8dn.plugins.a2pt.AndroidViewBundle
 import com.z8dn.plugins.a2pt.settings.AndroidViewSettings
 import com.z8dn.plugins.a2pt.settings.ProjectFileGroup
 import com.z8dn.plugins.a2pt.settings.ProjectFileGroupDialog
@@ -18,6 +19,9 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VfsUtil
 
 class IncludeDirectoryInGroupActionGroup : DefaultActionGroup() {
+    init {
+        templatePresentation.setText { AndroidViewBundle.message("action.ProjectView.IncludeDirectoryInGroup.text") }
+    }
 
     override fun getChildren(e: AnActionEvent?): Array<AnAction> {
         val event = e ?: return EMPTY_ARRAY
@@ -63,7 +67,7 @@ class IncludeDirectoryInGroupActionGroup : DefaultActionGroup() {
     private class CreateNewGroupAction(
         private val project: Project,
         private val dir: VirtualFile
-    ) : AnAction("New Group...") {
+    ) : AnAction({ AndroidViewBundle.message("action.CreateNewGroup.text") }) {
 
         override fun actionPerformed(e: AnActionEvent) {
             val pattern = buildPattern(project, dir) ?: return

--- a/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
+++ b/src/main/kotlin/com/z8dn/plugins/a2pt/utils/ProjectFileDisplayUtils.kt
@@ -5,16 +5,13 @@ import com.android.tools.idea.projectsystem.gradle.getGradleProjectPath
 import com.android.tools.idea.projectsystem.gradle.toHolder
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.VirtualFile
+import com.z8dn.plugins.a2pt.AndroidViewBundle
 
 /**
  * Utility object for generating display names and matching patterns for project files.
  * Provides shared functionality across different providers and nodes.
  */
 object ProjectFileDisplayUtils {
-
-    private const val MODULE_PREFIX = "Module "
-    private const val PROJECT_PREFIX = "Project: "
-    private const val BUILD_PREFIX = "Included build: "
 
     /**
      * Generates a display name for a file based on its type and module.
@@ -31,9 +28,9 @@ object ProjectFileDisplayUtils {
 
         // Determine the project display name with appropriate prefix
         val projectDisplayName = when {
-            gradleIdentityPath == ":" -> PROJECT_PREFIX + module.name
-            gradleProjectPath?.path == ":" -> BUILD_PREFIX + gradleIdentityPath
-            else -> MODULE_PREFIX + (gradleIdentityPath ?: module.name)
+            gradleIdentityPath == ":" -> AndroidViewBundle.message("display.ProjectPrefix", module.name)
+            gradleProjectPath?.path == ":" -> AndroidViewBundle.message("display.BuildPrefix", gradleIdentityPath ?: "")
+            else -> AndroidViewBundle.message("display.ModulePrefix", gradleIdentityPath ?: module.name)
         }
 
         // When files are shown in top-level group, always show the full prefix

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,7 +45,6 @@
     <actions>
         <group id="com.z8dn.plugins.a2pt.IncludeDirectoryGroup"
                class="com.z8dn.plugins.a2pt.actions.IncludeDirectoryInGroupActionGroup"
-               text="Include Directory in File Group"
                popup="true">
             <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </group>
@@ -59,9 +58,7 @@
             <action id="com.z8dn.plugins.a2pt.ShowProjectFilesInModuleAction"
                     class="com.z8dn.plugins.a2pt.actions.ShowProjectFilesInModuleAction"/>
             <action id="CustomizeAndroidTreeViewAction"
-                    class="com.z8dn.plugins.a2pt.actions.CustomizeAndroidTreeViewAction"
-                    text="Customize Android Tree View..."
-                    description="Open Advanced Android Project Tree settings"/>
+                    class="com.z8dn.plugins.a2pt.actions.CustomizeAndroidTreeViewAction"/>
         </group>
     </actions>
 </idea-plugin>

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -2,7 +2,7 @@
 action.ProjectView.ShowBuildDirectoryAction.text=Display Build Directory
 action.ProjectView.ShowProjectFilesInModuleAction.text=Display Project Files in Modules
 action.ProjectView.CustomizeAndroidTreeViewAction.text=Customize Android Tree View...
-action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project Tree Settings
+action.ProjectView.CustomizeAndroidTreeViewAction.description=Configure Android tree view
 action.ProjectView.IncludeDirectoryInGroup.text=Include Directory in File Group
 action.CreateNewGroup.text=New Group...
 

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -3,6 +3,8 @@ action.ProjectView.ShowBuildDirectoryAction.text=Display Build Directory
 action.ProjectView.ShowProjectFilesInModuleAction.text=Display Project Files in Modules
 action.ProjectView.CustomizeAndroidTreeViewAction.text=Customize Android Tree View...
 action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project Tree settings
+action.ProjectView.IncludeDirectoryInGroup.text=Include Directory in File Group
+action.CreateNewGroup.text=New Group...
 
 # Settings
 settings.DisplayName.text=Advanced Android Project Tree
@@ -30,3 +32,8 @@ dialog.Validation.NoInclusionPattern.text=At least one inclusion pattern (withou
 # Search Scope
 scope.ProjectFileGroups.DisplayName=Project File Groups
 scope.ProjectFileGroupScope.Prefix=Project File Group Scope:
+
+# Display Prefixes
+display.ModulePrefix=Module {0}
+display.ProjectPrefix=Project: {0}
+display.BuildPrefix=Included build: {0}

--- a/src/main/resources/messages/AndroidViewBundle.properties
+++ b/src/main/resources/messages/AndroidViewBundle.properties
@@ -2,7 +2,7 @@
 action.ProjectView.ShowBuildDirectoryAction.text=Display Build Directory
 action.ProjectView.ShowProjectFilesInModuleAction.text=Display Project Files in Modules
 action.ProjectView.CustomizeAndroidTreeViewAction.text=Customize Android Tree View...
-action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project Tree settings
+action.ProjectView.CustomizeAndroidTreeViewAction.description=Open Advanced Android Project Tree Settings
 action.ProjectView.IncludeDirectoryInGroup.text=Include Directory in File Group
 action.CreateNewGroup.text=New Group...
 


### PR DESCRIPTION
## Summary
- Added 5 new keys to `AndroidViewBundle.properties` for action text, display prefixes, and the "New Group..." label
- Removed hardcoded `text=`/`description=` from `plugin.xml` group and action declarations
- `CustomizeAndroidTreeViewAction`: text via lambda constructor, description via `init` block
- `IncludeDirectoryInGroupActionGroup`: group title via `templatePresentation.setText { }` init block
- `CreateNewGroupAction`: "New Group..." text via lambda constructor
- `ProjectFileDisplayUtils`: replaced 3 private string constants with `AndroidViewBundle.message()` calls using MessageFormat `{0}` placeholders

## Test plan
- [ ] Right-click a directory → "Include Directory in File Group" submenu appears with correct label
- [ ] "New Group..." item appears at the bottom of the submenu
- [ ] Project View gear menu shows "Customize Android Tree View..." and "Display Build Directory" actions
- [ ] File group nodes in the tree show correct "Module X" / "Project: X" / "Included build: X" prefixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internationalization**
  * Replaced hardcoded English text with localized resource strings throughout the Project View for improved multi-language support
  * Added new localized text resources for action labels and display prefixes
  * Enhanced UI text consistency for Project View actions and labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->